### PR TITLE
Added ignore references for rvm config files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@
 /spec/dummy/db/development.sqlite3
 /spec/dummy/db/test.sqlite3
 /*.gem
+
+# rvm config files
+.ruby-version
+.ruby-gemset


### PR DESCRIPTION
A simple addition to `.gitignore` that I always add anyway because I use rvm gemset config file settings. I dont want to mangle your code with my settings and I have to delete these files anytime I pull the latest code so I figured I'd fork it and make this pull request.