### PR TITLE
Fix concern aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,12 +121,16 @@ class User < ApplicationRecord
          :confirmable
 
   # including after calling the `devise` method is important.
+  # include DeviseTokenAuth::Concerns::User # is also valid (generator includes this one).
   include GraphqlDevise::Concerns::Model
 end
 ```
 
 The install generator can do this for you if you specify the `user_class` option.
 See [Installation](#Installation) for details.
+The generator will include a different module in your model, `DeviseTokenAuth::Concerns::User` which is also correct,
+we just made an alias on our namespace for consistency and possible extension.
+Generators have to be updated to generate our module.
 
 ### Customizing Email Templates
 The approach of this gem is a bit different from DeviseTokenAuth. We have placed our templates in `app/views/graphql_devise/mailer`,
@@ -145,6 +149,9 @@ In our example our model is `User`, so it would look like this:
 # app/controllers/my_controller.rb
 
 class MyController < ApplicationController
+  # include DeviseTokenAuth::Concerns::SetUserByToken # is also valid (generator includes this one).
+  include GraphqlDevise::Concerns::SetUserByToken
+
   before_action :authenticate_user!
 
   def my_action
@@ -155,6 +162,9 @@ end
 
 The install generator can do this for you because it executes DTA installer.
 See [Installation](#Installation) for details.
+The generator will include a different module in your model, `DeviseTokenAuth::Concerns::SetUserByToken` which is also correct,
+we just made an alias on our namespace for consistency and possible extension.
+Generators have to be updated to generate our module.
 
 ### Making Requests
 Here is a list of the available mutations and queries assuming your mounted model is `User`.

--- a/app/controllers/graphql_devise/concerns/set_user_by_token.rb
+++ b/app/controllers/graphql_devise/concerns/set_user_by_token.rb
@@ -1,5 +1,3 @@
-require 'devise_token_auth/concerns/set_user_by_token'
-
 module GraphqlDevise
   module Concerns
     SetUserByToken = DeviseTokenAuth::Concerns::SetUserByToken

--- a/app/models/graphql_devise/concerns/model.rb
+++ b/app/models/graphql_devise/concerns/model.rb
@@ -1,5 +1,3 @@
-require 'devise_token_auth/concerns/user'
-
 module GraphqlDevise
   module Concerns
     Model = DeviseTokenAuth::Concerns::User


### PR DESCRIPTION
Removes unnecessary requires which were causing an error when loading rails using `include GraphqlDevise::Concerns::SetUserByToken` on the controller.

Resolves #47 

Also makes docs clearer as discussed in #53. Not closing that one until generators include our own modules.