### PR TITLE
Fix routes GQL ruby (v1.10.0) version check

### DIFF
--- a/lib/graphql_devise/rails/routes.rb
+++ b/lib/graphql_devise/rails/routes.rb
@@ -67,7 +67,7 @@ module ActionDispatch::Routing
       end
 
       if (prepared_mutations.present? || additional_mutations.present?) &&
-         (Gem::Version.new(GraphQL::VERSION) <= Gem::Version.new('1.10.0') || GraphqlDevise::Schema.mutation.nil?)
+         (Gem::Version.new(GraphQL::VERSION) < Gem::Version.new('1.10.0') || GraphqlDevise::Schema.mutation.nil?)
         GraphqlDevise::Schema.mutation(GraphqlDevise::Types::MutationType)
       end
 


### PR DESCRIPTION
Small change but it would fail when using exactly `v1.10.0` of the graphql gem. I don't think we should change the appraisals for specs just because of this,