### PR TITLE
Make Authenticatable type not null

### DIFF
--- a/lib/graphql_devise/mount_method/operation_preparers/mutation_field_setter.rb
+++ b/lib/graphql_devise/mount_method/operation_preparers/mutation_field_setter.rb
@@ -7,7 +7,7 @@ module GraphqlDevise
         end
 
         def call(mutation)
-          mutation.field(:authenticatable, @authenticatable_type, null: true)
+          mutation.field(:authenticatable, @authenticatable_type, null: false)
 
           mutation
         end

--- a/lib/graphql_devise/mount_method/operation_preparers/resolver_type_setter.rb
+++ b/lib/graphql_devise/mount_method/operation_preparers/resolver_type_setter.rb
@@ -7,7 +7,7 @@ module GraphqlDevise
         end
 
         def call(resolver)
-          resolver.type(@authenticatable_type, null: true)
+          resolver.type(@authenticatable_type, null: false)
 
           resolver
         end

--- a/spec/services/mount_method/operation_preparers/mutation_field_setter_spec.rb
+++ b/spec/services/mount_method/operation_preparers/mutation_field_setter_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe GraphqlDevise::MountMethod::OperationPreparers::MutationFieldSett
     let(:field_type) { double(:type) }
 
     it 'sets a field for the mutation' do
-      expect(operation).to receive(:field).with(:authenticatable, field_type, null: true)
+      expect(operation).to receive(:field).with(:authenticatable, field_type, null: false)
 
       prepared_operation
     end

--- a/spec/services/mount_method/operation_preparers/resolver_type_setter_spec.rb
+++ b/spec/services/mount_method/operation_preparers/resolver_type_setter_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe GraphqlDevise::MountMethod::OperationPreparers::ResolverTypeSette
     let(:field_type) { double(:type) }
 
     it 'sets a field for the mutation' do
-      expect(operation).to receive(:type).with(field_type, null: true)
+      expect(operation).to receive(:type).with(field_type, null: false)
 
       prepared_operation
     end


### PR DESCRIPTION
- Makes `:authenticatable` field not null on default mutations
- Makes `:authenticatable` type not null on default resolvers

This should have never been nullable. An error is raised if for whatever reason the field cannot be returned.