### PR TITLE
Add queries to QueryType to avoid Unexpected parent_type error

### DIFF
--- a/lib/graphql_devise/rails/routes.rb
+++ b/lib/graphql_devise/rails/routes.rb
@@ -73,6 +73,11 @@ module ActionDispatch::Routing
         GraphqlDevise::Types::QueryType.field(:dummy, resolver: GraphqlDevise::Resolvers::Dummy)
       end
 
+      if prepared_queries.present? &&
+        (Gem::Version.new(GraphQL::VERSION) < Gem::Version.new('1.10.0') || GraphqlDevise::Schema.query.nil?)
+        GraphqlDevise::Schema.query(GraphqlDevise::Types::QueryType)
+      end
+
       Devise.mailer.helper(GraphqlDevise::MailerHelper)
 
       devise_scope resource.underscore.tr('/', '_').to_sym do


### PR DESCRIPTION
Resolves #85 

After a lot of digging, I found that adding the queries to the schema was missing. The error wasn't too helpful so it took a little bit of time.

Let me know your thoughts in case the issue is not somehow specific to my environment!
Not sure about the
```rails
Gem::Version.new(GraphQL::VERSION) < Gem::Version.new('1.10.0')
```
part also.

Thanks!