### PR TITLE
Add query and mutation type only once after app routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,0 +1,11 @@
+GraphqlDevise::Engine.routes.draw do
+  if GraphqlDevise::Types::QueryType.fields.blank?
+    GraphqlDevise::Types::QueryType.field(:dummy, resolver: GraphqlDevise::Resolvers::Dummy)
+  end
+
+  if GraphqlDevise::Types::MutationType.fields.present?
+    GraphqlDevise::Schema.mutation(GraphqlDevise::Types::MutationType)
+  end
+
+  GraphqlDevise::Schema.query(GraphqlDevise::Types::QueryType)
+end

--- a/lib/graphql_devise.rb
+++ b/lib/graphql_devise.rb
@@ -9,6 +9,7 @@ module GraphqlDevise
 end
 
 require 'graphql_devise/concerns/controller_methods'
+require 'graphql_devise/schema'
 require 'graphql_devise/types/authenticatable_type'
 require 'graphql_devise/types/credential_type'
 require 'graphql_devise/types/mutation_type'

--- a/lib/graphql_devise/rails/routes.rb
+++ b/lib/graphql_devise/rails/routes.rb
@@ -50,11 +50,6 @@ module ActionDispatch::Routing
         GraphqlDevise::Types::MutationType.field(action, mutation: mutation)
       end
 
-      if prepared_mutations.present? &&
-         (Gem::Version.new(GraphQL::VERSION) < Gem::Version.new('1.10.0') || GraphqlDevise::Schema.mutation.nil?)
-        GraphqlDevise::Schema.mutation(GraphqlDevise::Types::MutationType)
-      end
-
       prepared_queries = GraphqlDevise::MountMethod::OperationPreparer.new(
         resource:              resource,
         custom:                clean_options.operations,
@@ -67,10 +62,6 @@ module ActionDispatch::Routing
 
       prepared_queries.each do |action, resolver|
         GraphqlDevise::Types::QueryType.field(action, resolver: resolver)
-      end
-
-      if prepared_queries.blank? && GraphqlDevise::Types::QueryType.fields.blank?
-        GraphqlDevise::Types::QueryType.field(:dummy, resolver: GraphqlDevise::Resolvers::Dummy)
       end
 
       Devise.mailer.helper(GraphqlDevise::MailerHelper)

--- a/lib/graphql_devise/schema.rb
+++ b/lib/graphql_devise/schema.rb
@@ -1,5 +1,4 @@
 module GraphqlDevise
   class Schema < GraphQL::Schema
-    query(GraphqlDevise::Types::QueryType)
   end
 end


### PR DESCRIPTION
Adds Mutation and Query types to the schema only once unconditionally. Started as an effort to fix #85 but that one resolved itself. Still this was long overdue as we shouldn't rely on the internal behavior of the GQL gem and we were actually looking at weird behavior when mounting multiple  models.