### PR TITLE
Avoid multiple schema and type load (Devise behavior)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ cache: bundler
 before_install: gem install bundler -v 1.17
 before_script: RAILS_ENV=test bundle exec rake db:create db:schema:load
 
+env: EAGER_LOAD=true
+
 rvm:
   - 2.2.10
   - 2.3.8

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,16 @@
 GraphqlDevise::Engine.routes.draw do
-  if GraphqlDevise::Types::QueryType.fields.blank?
-    GraphqlDevise::Types::QueryType.field(:dummy, resolver: GraphqlDevise::Resolvers::Dummy)
-  end
+  # Required as Devise forces routes to reload on eager_load
+  unless GraphqlDevise.schema_loaded?
+    if GraphqlDevise::Types::QueryType.fields.blank?
+      GraphqlDevise::Types::QueryType.field(:dummy, resolver: GraphqlDevise::Resolvers::Dummy)
+    end
 
-  if GraphqlDevise::Types::MutationType.fields.present?
-    GraphqlDevise::Schema.mutation(GraphqlDevise::Types::MutationType)
-  end
+    if GraphqlDevise::Types::MutationType.fields.present?
+      GraphqlDevise::Schema.mutation(GraphqlDevise::Types::MutationType)
+    end
 
-  GraphqlDevise::Schema.query(GraphqlDevise::Types::QueryType)
+    GraphqlDevise::Schema.query(GraphqlDevise::Types::QueryType)
+
+    GraphqlDevise.load_schema
+  end
 end

--- a/lib/graphql_devise.rb
+++ b/lib/graphql_devise.rb
@@ -6,6 +6,25 @@ module GraphqlDevise
   class Error < StandardError; end
 
   class InvalidMountOptionsError < GraphqlDevise::Error; end
+
+  @schema_loaded     = false
+  @mounted_resources = []
+
+  def self.schema_loaded?
+    @schema_loaded
+  end
+
+  def self.load_schema
+    @schema_loaded = true
+  end
+
+  def self.mount_resource(resource)
+    @mounted_resources << resource
+  end
+
+  def self.resource_mounted?(resource)
+    @mounted_resources.include?(resource)
+  end
 end
 
 require 'graphql_devise/concerns/controller_methods'

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -10,7 +10,7 @@ Rails.application.configure do
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that
   # preloads Rails for running tests, you may have to set it to true.
-  config.eager_load = false
+  config.eager_load = ENV['EAGER_LOAD'].present?
 
   # Configure public file server for tests with Cache-Control for performance.
   if Rails::VERSION::MAJOR >= 5


### PR DESCRIPTION
Devise forces a reload on the routes when eager load is enabled (can be disabled from the initializer). This PR checks that type and schema loading happens only once even on route reload.