### PR TITLE
Fix set_resource_by_token no mapping error in no eager load envs

### DIFF
--- a/app/controllers/graphql_devise/concerns/set_user_by_token.rb
+++ b/app/controllers/graphql_devise/concerns/set_user_by_token.rb
@@ -5,12 +5,14 @@ module GraphqlDevise
     SetUserByToken.module_eval do
       attr_accessor :client_id, :token, :resource
 
-      alias_method :set_resource_by_token, :set_user_by_token
+      def set_resource_by_token(resource)
+        set_user_by_token(resource)
+      end
 
-      def graphql_context
+      def graphql_context(resource_name)
         {
-          current_resource: @resource,
-          controller:       self
+          resource_name: resource_name,
+          controller:    self
         }
       end
 

--- a/spec/dummy/app/controllers/api/v1/graphql_controller.rb
+++ b/spec/dummy/app/controllers/api/v1/graphql_controller.rb
@@ -3,14 +3,16 @@ module Api
     class GraphqlController < ApplicationController
       include GraphqlDevise::Concerns::SetUserByToken
 
-      before_action -> { set_resource_by_token(:user) }
-
       def graphql
-        render json: DummySchema.execute(params[:query], context: graphql_context)
+        render json: DummySchema.execute(params[:query], context: graphql_context(:user))
       end
 
       def interpreter
-        render json: InterpreterSchema.execute(params[:query], context: graphql_context)
+        render json: InterpreterSchema.execute(params[:query], context: graphql_context(:user))
+      end
+
+      def failing_resource_name
+        render json: DummySchema.execute(params[:query], context: graphql_context([:user, :fail]))
       end
 
       private

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -29,4 +29,5 @@ Rails.application.routes.draw do
 
   post '/api/v1/graphql', to: 'api/v1/graphql#graphql'
   post '/api/v1/interpreter', to: 'api/v1/graphql#interpreter'
+  post '/api/v1/failing', to: 'api/v1/graphql#failing_resource_name'
 end

--- a/spec/requests/user_controller_spec.rb
+++ b/spec/requests/user_controller_spec.rb
@@ -29,6 +29,15 @@ RSpec.describe "Integrations with the user's controller" do
         expect(json_response[:data][:publicField]).to eq('Field does not require authentication')
       end
     end
+
+    context 'when using the failing route' do
+      it 'raises an invalid resource_name error' do
+        expect { post_request('/api/v1/failing') }.to raise_error(
+          GraphqlDevise::Error,
+          'Invalid resource_name `fail` provided to `graphql_context`. Possible values are: [:user, :admin, :guest, :users_customer].'
+        )
+      end
+    end
   end
 
   describe 'privateField' do


### PR DESCRIPTION
Resolves #103 

Small breaking change (but was already broken). Now you don't need a `before_action` call with `set_resource_by_token(:resource)`. Instead, you just call `graphql_context` with one or an array of resource names like
```ruby
graphql_context(:resource)
```
passing an array will try to authenticate the resource for each resource name. This works if you mounted more than on resource in the `GraphqlDevise:: SchemaPlugin`.