### PR TITLE
Fix email reconfirmation feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,44 @@ end
 The install generator can do this for you if you specify the `user_class` option.
 See [Installation](#installation) for details.
 
+### Email Reconfirmation
+DTA and Devise support email reconfirmation. When the `confirmable` module is added to your
+resource, an email is sent to the provided email address when the `signUp` mutation is used.
+You can also use this gem so every time a user updates the `email` field, a new email gets sent
+for the user to confirm the new email address. Only after clicking on the confirmation link,
+the email will be updated on the database to use the new value.
+
+In order to use this feature there are a couple of things to setup first:
+1. Make user your model includes the `:confirmable` module.
+1. Add an `unconfirmed_email` String column to your resource's table.
+
+After that is done, you simply need to call a different update method on your resource,
+`update_with_email`. This method behaves exactly the same as ActiveRecord's `update` method
+if the previous steps are not performed, or if you are not updating the `email` attribute.
+It is also mandatory to provide two additional attributes when email will change or an error
+will be raised:
+
+1. `schema_url`: The full url where your GQL schema is mounted. You can get this value from the
+controller available in the context of your mutations and queries like this:
+```ruby
+  context[:controller].full_url_without_params
+```
+1. `confirmation_success_url`: This the full url where you want users to be redirected after
+the email has changed successfully (usually a front-end url). This value is mandatory
+unless you have set `default_confirm_success_url` in your devise_token_auth initializer.
+
+So, it's up to you where you require confirmation of changing emails.
+[Here's an example](https://github.com/graphql-devise/graphql_devise/blob/c4dcb17e98f8d84cc5ac002c66ed98a797d3bc82/spec/dummy/app/graphql/mutations/update_user.rb#L13)
+on how you might do this. And also a demonstration on the method usage:
+```ruby
+user.update_with_email(
+  name:                     'New Name',
+  email:                    'new@domain.com',
+  schema_url:               'http://localhost:3000/graphql',
+  confirmation_success_url: 'https://google.com'
+)
+```
+
 ### Customizing Email Templates
 The approach of this gem is a bit different from DeviseTokenAuth. We have placed our templates in `app/views/graphql_devise/mailer`,
 so if you want to change them, place yours on the same dir structure on your Rails project. You can customize these two templates:

--- a/app/controllers/graphql_devise/concerns/set_user_by_token.rb
+++ b/app/controllers/graphql_devise/concerns/set_user_by_token.rb
@@ -5,6 +5,10 @@ module GraphqlDevise
     SetUserByToken.module_eval do
       attr_accessor :client_id, :token, :resource
 
+      def full_url_without_params
+        request.base_url + request.path
+      end
+
       def set_resource_by_token(resource)
         set_user_by_token(resource)
       end

--- a/app/models/graphql_devise/concerns/model.rb
+++ b/app/models/graphql_devise/concerns/model.rb
@@ -5,8 +5,6 @@ module GraphqlDevise
     Model = DeviseTokenAuth::Concerns::User
 
     Model.module_eval do
-      attr_accessor :confirmation_url, :confirmation_success_url
-
       def update_with_email(attributes = {})
         GraphqlDevise::Model::WithEmailUpdater.new(self, attributes).call
       end

--- a/app/models/graphql_devise/concerns/model.rb
+++ b/app/models/graphql_devise/concerns/model.rb
@@ -1,5 +1,15 @@
+require 'graphql_devise/model/with_email_updater'
+
 module GraphqlDevise
   module Concerns
     Model = DeviseTokenAuth::Concerns::User
+
+    Model.module_eval do
+      attr_accessor :confirmation_url, :confirmation_success_url
+
+      def update_with_email(attributes = {})
+        GraphqlDevise::Model::WithEmailUpdater.new(self, attributes).call
+      end
+    end
   end
 end

--- a/app/views/graphql_devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/graphql_devise/mailer/confirmation_instructions.html.erb
@@ -2,4 +2,4 @@
 
 <p><%= t('.confirm_link_msg') %></p>
 
-<p><%= link_to t('.confirm_account_link'), url_for(controller: message['controller'], action: message['action'], **confirmation_query(resource_name: @resource.class.to_s, redirect_url: message['redirect-url'], token: @token)) %></p>
+<p><%= link_to t('.confirm_account_link'), "#{message['schema_url']}?#{confirmation_query(resource_name: @resource.class.to_s, redirect_url: message['redirect-url'], token: @token).to_query}" %></p>

--- a/app/views/graphql_devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/graphql_devise/mailer/reset_password_instructions.html.erb
@@ -2,7 +2,7 @@
 
 <p><%= t('.request_reset_link_msg') %></p>
 
-<p><%= link_to t('.password_change_link'), url_for(controller: message['controller'], action: message['action'], **password_reset_query(token: @token, redirect_url: message['redirect-url'], resource_name: @resource.class.to_s)) %></p>
+<p><%= link_to t('.password_change_link'), "#{message['schema_url']}?#{password_reset_query(token: @token, redirect_url: message['redirect-url'], resource_name: @resource.class.to_s).to_query}" %></p>
 
 <p><%= t('.ignore_mail_msg') %></p>
 <p><%= t('.no_changes_msg') %></p>

--- a/lib/graphql_devise/model/with_email_updater.rb
+++ b/lib/graphql_devise/model/with_email_updater.rb
@@ -8,41 +8,64 @@ module GraphqlDevise
 
       def call
         resource_attributes = @attributes.except(:schema_url, :confirmation_success_url)
+        return @resource.update(resource_attributes) unless requires_reconfirmation?(resource_attributes)
 
-        if resource_attributes.key?(:email) && @resource.respond_to?(:unconfirmed_email=)
-          unless @attributes[:schema_url].present? && (@attributes[:confirmation_success_url].present? || DeviseTokenAuth.default_confirm_success_url.present?)
-            raise(
-              GraphqlDevise::Error,
-              'Method `update_with_email` requires attributes `confirmation_success_url` and `schema_url` for email reconfirmation to work'
-            )
-          end
+        @resource.assign_attributes(resource_attributes)
 
-          @resource.assign_attributes(resource_attributes)
+        if @resource.email == email_in_database
+          return @resource.save
+        elsif required_reconfirm_attributes?
           return false unless @resource.valid?
 
-          @resource.unconfirmed_email  = @resource.email
-          @resource.confirmation_token = nil
-          @resource.email              = if Devise.activerecord51?
-            @resource.email_in_database
-          else
-            @resource.email_was
-          end
-          @resource.send(:generate_confirmation_token)
-
+          store_unconfirmed_email
           saved = @resource.save
-
-          if saved
-            @resource.send_confirmation_instructions(
-              redirect_url:  @attributes[:confirmation_success_url] || DeviseTokenAuth.default_confirm_success_url,
-              template_path: ['graphql_devise/mailer'],
-              schema_url:    @attributes[:schema_url]
-            )
-          end
+          send_confirmation_instructions(saved)
 
           saved
         else
-          @resource.update(resource_attributes)
+          raise(
+            GraphqlDevise::Error,
+            'Method `update_with_email` requires attributes `confirmation_success_url` and `schema_url` for email reconfirmation to work'
+          )
         end
+      end
+
+      private
+
+      def required_reconfirm_attributes?
+        @attributes[:schema_url].present? &&
+          (@attributes[:confirmation_success_url].present? || DeviseTokenAuth.default_confirm_success_url.present?)
+      end
+
+      def requires_reconfirmation?(resource_attributes)
+        resource_attributes.key?(:email) &&
+          @resource.devise_modules.include?(:confirmable) &&
+          @resource.respond_to?(:unconfirmed_email=)
+      end
+
+      def store_unconfirmed_email
+        @resource.unconfirmed_email  = @resource.email
+        @resource.confirmation_token = nil
+        @resource.email              = email_in_database
+        @resource.send(:generate_confirmation_token)
+      end
+
+      def email_in_database
+        if Devise.activerecord51?
+          @resource.email_in_database
+        else
+          @resource.email_was
+        end
+      end
+
+      def send_confirmation_instructions(saved)
+        return unless saved
+
+        @resource.send_confirmation_instructions(
+          redirect_url:  @attributes[:confirmation_success_url] || DeviseTokenAuth.default_confirm_success_url,
+          template_path: ['graphql_devise/mailer'],
+          schema_url:    @attributes[:schema_url]
+        )
       end
     end
   end

--- a/lib/graphql_devise/model/with_email_updater.rb
+++ b/lib/graphql_devise/model/with_email_updater.rb
@@ -1,0 +1,49 @@
+module GraphqlDevise
+  module Model
+    class WithEmailUpdater
+      def initialize(resource, attributes)
+        @attributes = attributes
+        @resource   = resource
+      end
+
+      def call
+        resource_attributes = @attributes.except(:schema_url, :confirmation_success_url)
+
+        if resource_attributes.key?(:email) && @resource.respond_to?(:unconfirmed_email=)
+          unless @attributes[:schema_url].present? && (@attributes[:confirmation_success_url].present? || DeviseTokenAuth.default_confirm_success_url.present?)
+            raise(
+              GraphqlDevise::Error,
+              'Method `update_with_email` requires attributes `confirmation_success_url` and `schema_url` for email reconfirmation to work'
+            )
+          end
+
+          @resource.assign_attributes(resource_attributes)
+          return false unless @resource.valid?
+
+          @resource.unconfirmed_email  = @resource.email
+          @resource.confirmation_token = nil
+          @resource.email              = if Devise.activerecord51?
+            @resource.email_in_database
+          else
+            @resource.email_was
+          end
+          @resource.send(:generate_confirmation_token)
+
+          saved = @resource.save
+
+          if saved
+            @resource.send_confirmation_instructions(
+              redirect_url:  @attributes[:confirmation_success_url] || DeviseTokenAuth.default_confirm_success_url,
+              template_path: ['graphql_devise/mailer'],
+              schema_url:    @attributes[:schema_url]
+            )
+          end
+
+          saved
+        else
+          @resource.update(resource_attributes)
+        end
+      end
+    end
+  end
+end

--- a/lib/graphql_devise/mutations/resend_confirmation.rb
+++ b/lib/graphql_devise/mutations/resend_confirmation.rb
@@ -20,7 +20,7 @@ module GraphqlDevise
           resource.send_confirmation_instructions(
             redirect_url:  redirect_url,
             template_path: ['graphql_devise/mailer'],
-            **controller.params.permit('controller', 'action').to_h.symbolize_keys
+            schema_url:    controller.full_url_without_params
           )
 
           { message: I18n.t('graphql_devise.confirmations.send_instructions', email: email) }

--- a/lib/graphql_devise/mutations/send_password_reset.rb
+++ b/lib/graphql_devise/mutations/send_password_reset.rb
@@ -17,7 +17,7 @@ module GraphqlDevise
             provider:      'email',
             redirect_url:  redirect_url,
             template_path: ['graphql_devise/mailer'],
-            **controller.params.permit('controller', 'action').to_h.symbolize_keys
+            schema_url:    controller.full_url_without_params
           )
 
           if resource.errors.empty?

--- a/lib/graphql_devise/mutations/sign_up.rb
+++ b/lib/graphql_devise/mutations/sign_up.rb
@@ -28,7 +28,7 @@ module GraphqlDevise
             resource.send_confirmation_instructions(
               redirect_url:  confirm_success_url,
               template_path: ['graphql_devise/mailer'],
-              **controller.params.permit('controller', 'action').to_h.symbolize_keys
+              schema_url:    controller.full_url_without_params
             )
           end
 

--- a/lib/graphql_devise/resolvers/confirm_account.rb
+++ b/lib/graphql_devise/resolvers/confirm_account.rb
@@ -13,10 +13,10 @@ module GraphqlDevise
           redirect_header_options = { account_confirmation_success: true }
 
           redirect_to_link = if controller.signed_in?(resource_name)
-            signed_in_resource.build_auth_url(
+            resource.build_auth_url(
               redirect_url,
               redirect_headers(
-                client_and_token(controller.signed_in_resource.create_token),
+                client_and_token(resource.create_token),
                 redirect_header_options
               )
             )

--- a/spec/dummy/app/graphql/mutations/update_user.rb
+++ b/spec/dummy/app/graphql/mutations/update_user.rb
@@ -1,0 +1,20 @@
+module Mutations
+  class UpdateUser < GraphQL::Schema::Mutation
+    field :user, Types::UserType, null: false
+
+    argument :email, String, required: false
+    argument :name,  String, required: false
+
+    def resolve(**attrs)
+      user = context[:current_resource]
+
+      schema_url = context[:controller].full_url_without_params
+
+      user.update_with_email(
+        attrs.merge(schema_url: schema_url, confirmation_success_url: 'https://google.com')
+      )
+
+      { user: user }
+    end
+  end
+end

--- a/spec/dummy/app/graphql/types/mutation_type.rb
+++ b/spec/dummy/app/graphql/types/mutation_type.rb
@@ -1,6 +1,7 @@
 module Types
   class MutationType < Types::BaseObject
     field :dummy_mutation, String, null: false, authenticate: true
+    field :update_user, mutation: Mutations::UpdateUser
 
     def dummy_mutation
       'Necessary so GraphQL gem does not complain about empty mutation type'

--- a/spec/dummy/config/initializers/devise_token_auth.rb
+++ b/spec/dummy/config/initializers/devise_token_auth.rb
@@ -37,6 +37,8 @@ DeviseTokenAuth.setup do |config|
   # password is updated.
   config.check_current_password_before_update = :password
 
+  config.default_confirm_success_url = 'https://google.com'
+
   # By default we will use callbacks for single omniauth.
   # It depends on fields like email, provider and uid.
   # config.default_callbacks = true

--- a/spec/dummy/db/migrate/20200621182414_remove_uncofirmed_email_from_admins.rb
+++ b/spec/dummy/db/migrate/20200621182414_remove_uncofirmed_email_from_admins.rb
@@ -1,0 +1,5 @@
+class RemoveUncofirmedEmailFromAdmins < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :admins, :unconfirmed_email, :string
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_21_121807) do
+ActiveRecord::Schema.define(version: 2020_06_21_182414) do
 
   create_table "admins", force: :cascade do |t|
     t.string "provider", default: "email", null: false
@@ -22,7 +22,6 @@ ActiveRecord::Schema.define(version: 2020_03_21_121807) do
     t.string "confirmation_token"
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
-    t.string "unconfirmed_email"
     t.string "email"
     t.text "tokens"
     t.datetime "created_at", null: false

--- a/spec/graphql_devise/model/with_email_updater_spec.rb
+++ b/spec/graphql_devise/model/with_email_updater_spec.rb
@@ -1,0 +1,87 @@
+require 'rails_helper'
+
+RSpec.describe GraphqlDevise::Model::WithEmailUpdater do
+  describe '#call' do
+    subject(:updater) { described_class.new(resource, attributes).call }
+
+    context 'when the model does not have an unconfirmed_email column' do
+      let(:resource) { create(:admin, :confirmed) }
+
+      context 'when attributes contain email' do
+        let(:attributes) { { email: 'new@gmail.com', schema_url: 'http://localhost/test', confirmation_success_url: 'https://google.com' } }
+
+        it 'does not postpone email update' do
+          expect do
+            updater
+            resource.reload
+          end.to change(resource, :email).from(resource.email).to('new@gmail.com').and(
+            change(resource, :uid).from(resource.uid).to('new@gmail.com')
+          )
+        end
+      end
+    end
+
+    context 'when the model has an unconfirmed_email column' do
+      let(:resource) { create(:user, :confirmed) }
+
+      context 'when attributes do not contain email' do
+        let(:attributes) { { name: 'Updated Name', schema_url: 'http://localhost/test', confirmation_success_url: 'https://google.com' } }
+
+        it 'updates resource, ignores url params' do
+          expect do
+            updater
+            resource.reload
+          end.to change(resource, :name).from(resource.name).to('Updated Name')
+        end
+      end
+
+      context 'when attributes contain email' do
+        context 'when schema_url is missing' do
+          let(:attributes) { { email: 'new@gmail.com', name: 'Updated Name' } }
+
+          it 'raises an error' do
+            expect { updater }.to raise_error(
+              GraphqlDevise::Error,
+              'Method `update_with_email` requires attributes `confirmation_success_url` and `schema_url` for email reconfirmation to work'
+            )
+          end
+        end
+
+        context 'when only confirmation_success_url is missing' do
+          let(:attributes) { { email: 'new@gmail.com', name: 'Updated Name', schema_url: 'http://localhost/test' } }
+
+          it 'uses DTA default_confirm_success_url on the email' do
+            expect { updater }.to change(ActionMailer::Base.deliveries, :count).by(1)
+
+            email = ActionMailer::Base.deliveries.first
+            expect(email.body.decoded).to include(CGI.escape('https://google.com'))
+          end
+        end
+
+        context 'when both required urls are provided' do
+          let(:attributes) { { email: 'new@gmail.com', name: 'Updated Name', schema_url: 'http://localhost/test', confirmation_success_url: 'https://google.com' } }
+
+          it 'postpones email update' do
+            expect do
+              updater
+              resource.reload
+            end.to not_change(resource, :email).from(resource.email).and(
+              not_change(resource, :uid).from(resource.uid)
+            ).and(
+              change(resource, :unconfirmed_email).from(nil).to('new@gmail.com')
+            ).and(
+              change(resource, :name).from(resource.name).to('Updated Name')
+            )
+          end
+
+          it 'sends out a confirmation email to the unconfirmed_email' do
+            expect { updater }.to change(ActionMailer::Base.deliveries, :count).by(1)
+
+            email = ActionMailer::Base.deliveries.first
+            expect(email.to).to contain_exactly('new@gmail.com')
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -42,4 +42,5 @@ RSpec.configure do |config|
   config.before(:suite) do
     ActionController::Base.allow_forgery_protection = true
   end
+  config.before { ActionMailer::Base.deliveries.clear }
 end

--- a/spec/requests/queries/confirm_account_spec.rb
+++ b/spec/requests/queries/confirm_account_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Account confirmation' do
       user.send_confirmation_instructions(
         template_path: ['graphql_devise/mailer'],
         controller:    'graphql_devise/graphql',
-        action:        'auth'
+        schema_url:    'http://not-using-this-value.com/gql'
       )
     end
 


### PR DESCRIPTION
Resolves #102 

Fixes email reconfirmation by introducing a new mechanism/method to do that. More explicit than DTA or Devise's way.

New method available in your model, `update_with_email`. Works just like `update` if your model doesn't have an `unconfirmed_email` column. If the column is present, and `email` is provided as part of the attributes to the method, two more attributes are required:
`schema_url`
`confirmation_success_url ` (optional if you have configured `default_confirm_success_url`) in your DeviseTokenAuth initializer.

### Breaking change
A small breaking change is introduced. Now the email templates receive a `schema_url` value in the `message` object, instead of the `action` and `controller` values. Your mailer views might need to be updated if you overrode the default ones.