### PR TITLE
Fix cookie overflow. Warden resource serialization

### DIFF
--- a/lib/graphql_devise/schema_plugin.rb
+++ b/lib/graphql_devise/schema_plugin.rb
@@ -11,6 +11,7 @@ module GraphqlDevise
 
       # Must happen on initialize so operations are loaded before the types are added to the schema on GQL < 1.10
       load_fields
+      reconfigure_warden!
     end
 
     def use(schema_definition)
@@ -90,6 +91,11 @@ module GraphqlDevise
       else
         field.graphql_definition.metadata[:authenticate]
       end
+    end
+
+    def reconfigure_warden!
+      Devise.class_variable_set(:@@warden_configured, nil)
+      Devise.configure_warden!
     end
 
     def load_fields

--- a/spec/dummy/app/controllers/api/v1/graphql_controller.rb
+++ b/spec/dummy/app/controllers/api/v1/graphql_controller.rb
@@ -23,7 +23,7 @@ module Api
         {
           operation_name: item[:operationName],
           variables:      ensure_hash(item[:variables]),
-          context:        graphql_context(:user)
+          context:        graphql_context([:user, :schema_user])
         }
       end
 

--- a/spec/dummy/app/graphql/dummy_schema.rb
+++ b/spec/dummy/app/graphql/dummy_schema.rb
@@ -13,7 +13,8 @@ class DummySchema < GraphQL::Schema
           :check_password_token
         ]
       ),
-      GraphqlDevise::ResourceLoader.new('Guest', only: [:logout])
+      GraphqlDevise::ResourceLoader.new('Guest', only: [:logout]),
+      GraphqlDevise::ResourceLoader.new('SchemaUser')
     ]
   )
 

--- a/spec/dummy/app/models/schema_user.rb
+++ b/spec/dummy/app/models/schema_user.rb
@@ -1,0 +1,11 @@
+class SchemaUser < ApplicationRecord
+  devise :database_authenticatable,
+         :recoverable,
+         :trackable,
+         :validatable,
+         :confirmable
+
+  include GraphqlDevise::Concerns::Model
+
+  validates :name, presence: true
+end

--- a/spec/dummy/db/migrate/20200623003142_create_schema_users.rb
+++ b/spec/dummy/db/migrate/20200623003142_create_schema_users.rb
@@ -1,0 +1,44 @@
+class CreateSchemaUsers < ActiveRecord::Migration[6.0]
+  def change
+    create_table :schema_users do |t|
+      ## Required
+      t.string :provider, null: false, default: 'email'
+      t.string :uid, null: false, default: ''
+
+      ## Database authenticatable
+      t.string :encrypted_password, null: false, default: ''
+
+      ## Recoverable
+      t.string   :reset_password_token
+      t.datetime :reset_password_sent_at
+      t.boolean  :allow_password_change, default: false
+
+      ## Confirmable
+      t.string   :confirmation_token
+      t.datetime :confirmed_at
+      t.datetime :confirmation_sent_at
+
+      # Trackable
+      t.datetime :current_sign_in_at
+      t.datetime :last_sign_in_at
+      t.string   :last_sign_in_ip
+      t.string   :current_sign_in_ip
+      t.integer  :sign_in_count
+
+      ## User Info
+      t.string :name
+      t.string :email
+
+      ## Tokens
+      t.text :tokens
+
+      t.timestamps
+    end
+
+    add_index :schema_users, :email,                unique: true
+    add_index :schema_users, [:uid, :provider],     unique: true
+    add_index :schema_users, :reset_password_token, unique: true
+    add_index :schema_users, :confirmation_token,   unique: true
+    add_index :schema_users, :unlock_token,         unique: true
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_21_182414) do
+ActiveRecord::Schema.define(version: 2020_06_23_003142) do
 
   create_table "admins", force: :cascade do |t|
     t.string "provider", default: "email", null: false
@@ -51,6 +51,33 @@ ActiveRecord::Schema.define(version: 2020_06_21_182414) do
     t.index ["email"], name: "index_guests_on_email", unique: true
     t.index ["reset_password_token"], name: "index_guests_on_reset_password_token", unique: true
     t.index ["uid", "provider"], name: "index_guests_on_uid_and_provider", unique: true
+  end
+
+  create_table "schema_users", force: :cascade do |t|
+    t.string "provider", default: "email", null: false
+    t.string "uid", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.boolean "allow_password_change", default: false
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.string "last_sign_in_ip"
+    t.string "current_sign_in_ip"
+    t.integer "sign_in_count"
+    t.string "name"
+    t.string "email"
+    t.text "tokens"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index "\"unlock_token\"", name: "index_schema_users_on_unlock_token", unique: true
+    t.index ["confirmation_token"], name: "index_schema_users_on_confirmation_token", unique: true
+    t.index ["email"], name: "index_schema_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_schema_users_on_reset_password_token", unique: true
+    t.index ["uid", "provider"], name: "index_schema_users_on_uid_and_provider", unique: true
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/factories/schema_users.rb
+++ b/spec/factories/schema_users.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :schema_user do
+    name      { Faker::FunnyName.two_word_name }
+    email     { Faker::Internet.unique.email }
+    password  { Faker::Internet.password }
+
+    trait :confirmed do
+      confirmed_at { Time.zone.now }
+    end
+  end
+end

--- a/spec/requests/user_controller_spec.rb
+++ b/spec/requests/user_controller_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "Integrations with the user's controller" do
       it 'raises an invalid resource_name error' do
         expect { post_request('/api/v1/failing') }.to raise_error(
           GraphqlDevise::Error,
-          'Invalid resource_name `fail` provided to `graphql_context`. Possible values are: [:user, :admin, :guest, :users_customer].'
+          'Invalid resource_name `fail` provided to `graphql_context`. Possible values are: [:user, :admin, :guest, :users_customer, :schema_user].'
         )
       end
     end
@@ -55,8 +55,16 @@ RSpec.describe "Integrations with the user's controller" do
       context 'when user is authenticated' do
         let(:headers) { user.create_new_auth_token }
 
-        it 'allow to perform the query' do
+        it 'allows to perform the query' do
           expect(json_response[:data][:privateField]).to eq('Field will always require authentication')
+        end
+
+        context 'when using a SchemaUser' do
+          let(:headers) { create(:schema_user, :confirmed).create_new_auth_token }
+
+          it 'allows to perform the query' do
+            expect(json_response[:data][:privateField]).to eq('Field will always require authentication')
+          end
         end
       end
 
@@ -75,7 +83,7 @@ RSpec.describe "Integrations with the user's controller" do
       context 'when user is authenticated' do
         let(:headers) { user.create_new_auth_token }
 
-        it 'allow to perform the query' do
+        it 'allows to perform the query' do
           expect(json_response[:data][:privateField]).to eq('Field will always require authentication')
         end
       end
@@ -105,7 +113,7 @@ RSpec.describe "Integrations with the user's controller" do
       context 'when user is authenticated' do
         let(:headers) { user.create_new_auth_token }
 
-        it 'allow to perform the query' do
+        it 'allows to perform the query' do
           expect(json_response[:data][:dummyMutation]).to eq('Necessary so GraphQL gem does not complain about empty mutation type')
         end
       end
@@ -125,7 +133,7 @@ RSpec.describe "Integrations with the user's controller" do
       context 'when user is authenticated' do
         let(:headers) { user.create_new_auth_token }
 
-        it 'allow to perform the query' do
+        it 'allows to perform the query' do
           expect(json_response[:data][:dummyMutation]).to eq('Necessary so GraphQL gem does not complain about empty mutation type')
         end
       end
@@ -160,7 +168,7 @@ RSpec.describe "Integrations with the user's controller" do
       context 'when user is authenticated' do
         let(:headers) { user.create_new_auth_token }
 
-        it 'allow to perform the query' do
+        it 'allows to perform the query' do
           expect(json_response[:data][:user]).to match(
             email: user.email,
             id:    user.id
@@ -183,7 +191,7 @@ RSpec.describe "Integrations with the user's controller" do
       context 'when user is authenticated' do
         let(:headers) { user.create_new_auth_token }
 
-        it 'allow to perform the query' do
+        it 'allows to perform the query' do
           expect(json_response[:data][:user]).to match(
             email: user.email,
             id:    user.id
@@ -193,7 +201,7 @@ RSpec.describe "Integrations with the user's controller" do
 
       context 'when user is not authenticated' do
         # Interpreter schema fields are public unless specified otherwise (plugin setting)
-        it 'allow to perform the query' do
+        it 'allows to perform the query' do
           expect(json_response[:data][:user]).to match(
             email: user.email,
             id:    user.id


### PR DESCRIPTION
Fixes #112 

Needed to reconfigure warden resource serializers after routes are run for those resources that are not mounted through the routes mount_method