### PR TITLE
Fix unconfirmed_email confirmation. Ignore devise reconfirmable config.

### DIFF
--- a/app/models/graphql_devise/concerns/model.rb
+++ b/app/models/graphql_devise/concerns/model.rb
@@ -10,6 +10,12 @@ module GraphqlDevise
       def update_with_email(attributes = {})
         GraphqlDevise::Model::WithEmailUpdater.new(self, attributes).call
       end
+
+      private
+
+      def pending_reconfirmation?
+        devise_modules.include?(:confirmable) && try(:unconfirmed_email).present?
+      end
     end
   end
 end

--- a/spec/dummy/app/graphql/resolvers/confirm_admin_account.rb
+++ b/spec/dummy/app/graphql/resolvers/confirm_admin_account.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Resolvers
+  class ConfirmAdminAccount < GraphqlDevise::Resolvers::ConfirmAccount
+    type Types::AdminType, null: false
+
+    def resolve(confirmation_token:, redirect_url:)
+      super do |admin|
+        controller.sign_in(admin)
+      end
+    end
+  end
+end

--- a/spec/dummy/app/graphql/types/admin_type.rb
+++ b/spec/dummy/app/graphql/types/admin_type.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Types
+  class AdminType < GraphQL::Schema::Object
+    field :id,    Int,    null: false
+    field :email, String, null: false
+  end
+end

--- a/spec/dummy/config/initializers/devise.rb
+++ b/spec/dummy/config/initializers/devise.rb
@@ -142,7 +142,7 @@ Devise.setup do |config|
   # initial account confirmation) to be applied. Requires additional unconfirmed_email
   # db field (see migrations). Until confirmed, new email is stored in
   # unconfirmed_email column, and copied to email column on successful confirmation.
-  config.reconfirmable = true
+  config.reconfirmable = false
 
   # Defines which key will be used when confirming an account
   # config.confirmation_keys = [:email]

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -14,6 +14,9 @@ Rails.application.routes.draw do
     'Admin',
     authenticatable_type: Types::CustomAdminType,
     skip:                 [:sign_up, :check_password_token],
+    operations:           {
+      confirm_account: Resolvers::ConfirmAdminAccount
+    },
     at:                   '/api/v1/admin/graphql_auth'
   )
 

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.

--- a/spec/requests/queries/confirm_account_spec.rb
+++ b/spec/requests/queries/confirm_account_spec.rb
@@ -5,60 +5,118 @@ require 'rails_helper'
 RSpec.describe 'Account confirmation' do
   include_context 'with graphql query request'
 
-  let(:user)     { create(:user, confirmed_at: nil) }
-  let(:redirect) { Faker::Internet.url }
-  let(:query) do
-    <<-GRAPHQL
-      {
-        userConfirmAccount(
-          confirmationToken: "#{token}"
-          redirectUrl:       "#{redirect}"
-        ) {
-          email
-          name
+  context 'when using the user model' do
+    let(:user)     { create(:user, confirmed_at: nil) }
+    let(:redirect) { Faker::Internet.url }
+    let(:query) do
+      <<-GRAPHQL
+        {
+          userConfirmAccount(
+            confirmationToken: "#{token}"
+            redirectUrl:       "#{redirect}"
+          ) {
+            email
+            name
+          }
         }
-      }
-    GRAPHQL
-  end
-
-  context 'when confirmation token is correct' do
-    let(:token) { user.confirmation_token }
-
-    before do
-      user.send_confirmation_instructions(
-        template_path: ['graphql_devise/mailer'],
-        controller:    'graphql_devise/graphql',
-        schema_url:    'http://not-using-this-value.com/gql'
-      )
+      GRAPHQL
     end
 
-    it 'confirms the resource and redirects to the sent url' do
-      expect do
-        get_request
-        user.reload
-      end.to(change(user, :confirmed_at).from(nil))
+    context 'when confirmation token is correct' do
+      let(:token) { user.confirmation_token }
 
-      expect(response).to redirect_to "#{redirect}?account_confirmation_success=true"
-      expect(user).to be_active_for_authentication
-    end
-  end
-
-  context 'when reset password token is not found' do
-    let(:token) { "#{user.confirmation_token}-invalid" }
-
-    it 'does *NOT* confirm the user nor does the redirection' do
-      expect do
-        get_request
-        user.reload
-      end.not_to(change(user, :confirmed_at).from(nil))
-
-      expect(response).not_to be_redirect
-      expect(json_response[:errors]).to contain_exactly(
-        hash_including(
-          message: 'Invalid confirmation token. Please try again',
-          extensions: { code: 'USER_ERROR' }
+      before do
+        user.send_confirmation_instructions(
+          template_path: ['graphql_devise/mailer'],
+          controller:    'graphql_devise/graphql',
+          schema_url:    'http://not-using-this-value.com/gql'
         )
-      )
+      end
+
+      it 'confirms the resource and redirects to the sent url' do
+        expect do
+          get_request
+          user.reload
+        end.to(change(user, :confirmed_at).from(nil))
+
+        expect(response).to redirect_to("#{redirect}?account_confirmation_success=true")
+        expect(user).to be_active_for_authentication
+      end
+
+      context 'when unconfirmed_email is present' do
+        let(:user) { create(:user, :confirmed, unconfirmed_email: 'vvega@wallaceinc.com') }
+
+        it 'confirms the unconfirmed email and redirects' do
+          expect do
+            get_request
+            user.reload
+          end.to change(user, :email).from(user.email).to('vvega@wallaceinc.com').and(
+            change(user, :unconfirmed_email).from('vvega@wallaceinc.com').to(nil)
+          )
+
+          expect(response).to redirect_to("#{redirect}?account_confirmation_success=true")
+        end
+      end
+    end
+
+    context 'when reset password token is not found' do
+      let(:token) { "#{user.confirmation_token}-invalid" }
+
+      it 'does *NOT* confirm the user nor does the redirection' do
+        expect do
+          get_request
+          user.reload
+        end.not_to(change(user, :confirmed_at).from(nil))
+
+        expect(response).not_to be_redirect
+        expect(json_response[:errors]).to contain_exactly(
+          hash_including(
+            message:    'Invalid confirmation token. Please try again',
+            extensions: { code: 'USER_ERROR' }
+          )
+        )
+      end
+    end
+  end
+
+  context 'when using the admin model' do
+    let(:admin)    { create(:admin, confirmed_at: nil) }
+    let(:redirect) { Faker::Internet.url }
+    let(:query) do
+      <<-GRAPHQL
+        {
+          adminConfirmAccount(
+            confirmationToken: "#{token}"
+            redirectUrl:       "#{redirect}"
+          ) {
+            email
+          }
+        }
+      GRAPHQL
+    end
+
+    context 'when confirmation token is correct' do
+      let(:token) { admin.confirmation_token }
+
+      before do
+        admin.send_confirmation_instructions(
+          template_path: ['graphql_devise/mailer'],
+          controller:    'graphql_devise/graphql',
+          schema_url:    'http://not-using-this-value.com/gql'
+        )
+      end
+
+      it 'confirms the resource, persists credentials on the DB and redirects to the sent url' do
+        expect do
+          get_request
+          admin.reload
+        end.to change(admin, :confirmed_at).from(nil).and(
+          change { admin.tokens.keys.count }.from(0).to(1)
+        )
+
+        expect(response).to redirect_to(/\A#{redirect}.+access\-token=/)
+        expect(admin).to be_active_for_authentication
+      end
     end
   end
 end


### PR DESCRIPTION
- Added missing specs for #125 
- Fixes broken scenario where `Devise.reconfirmable = false` and `unconfirmed_email` is present after clicking on the confirmation link 