### PR TITLE
Allow resend of confirmation with unconfirmed email

### DIFF
--- a/app/models/graphql_devise/concerns/model.rb
+++ b/app/models/graphql_devise/concerns/model.rb
@@ -11,8 +11,6 @@ module GraphqlDevise
         GraphqlDevise::Model::WithEmailUpdater.new(self, attributes).call
       end
 
-      private
-
       def pending_reconfirmation?
         devise_modules.include?(:confirmable) && try(:unconfirmed_email).present?
       end

--- a/lib/graphql_devise/mutations/resend_confirmation.rb
+++ b/lib/graphql_devise/mutations/resend_confirmation.rb
@@ -9,15 +9,14 @@ module GraphqlDevise
       field :message, String, null: false
 
       def resolve(email:, redirect_url:)
-        resource = find_resource(
-          :email,
-          get_case_insensitive_field(:email, email)
-        )
+        resource = find_confirmable_resource(email)
 
         if resource
           yield resource if block_given?
 
-          raise_user_error(I18n.t('graphql_devise.confirmations.already_confirmed')) if resource.confirmed?
+          if resource.confirmed? && !resource.pending_reconfirmation?
+            raise_user_error(I18n.t('graphql_devise.confirmations.already_confirmed'))
+          end
 
           resource.send_confirmation_instructions(
             redirect_url:  redirect_url,
@@ -29,6 +28,15 @@ module GraphqlDevise
         else
           raise_user_error(I18n.t('graphql_devise.confirmations.user_not_found', email: email))
         end
+      end
+
+      private
+
+      def find_confirmable_resource(email)
+        email_insensitive = get_case_insensitive_field(:email, email)
+        resource = find_resource(:unconfirmed_email, email_insensitive) if resource_class.reconfirmable
+        resource ||= find_resource(:email, email_insensitive)
+        resource
       end
     end
   end

--- a/spec/requests/mutations/resend_confirmation_spec.rb
+++ b/spec/requests/mutations/resend_confirmation_spec.rb
@@ -98,6 +98,29 @@ RSpec.describe 'Resend confirmation' do
     end
   end
 
+  context 'when the email was changed' do
+    let(:email) { 'new-email@wallaceinc.com' }
+    let(:new_email) { email }
+
+    before do
+      user.class.reconfirmable = true
+      user.confirm
+      user.update_with_email(
+        email:                    new_email,
+        schema_url:               'http://localhost/test',
+        confirmation_success_url: 'https://google.com'
+      )
+    end
+
+    it 'sends new confirmation email' do
+      expect { post_request }.to change(ActionMailer::Base.deliveries, :count).by(1)
+      expect(ActionMailer::Base.deliveries.first.to).to contain_exactly(new_email)
+      expect(json_response[:data][:userResendConfirmation]).to include(
+        message: 'You will receive an email with instructions for how to confirm your email address in a few minutes.'
+      )
+    end
+  end
+
   context "when the email isn't in the system" do
     let(:email) { 'nothere@gmail.com' }
 


### PR DESCRIPTION
See original handling of resend request where unconfirmed_email is looked up first when confirmable module is used: https://github.com/heartcombo/devise/blob/507573994a5524e17729f5c8e340ec6678ff26a5/lib/devise/models/confirmable.rb#L338-L341

Also, method `pending_reconfirmation?` is public in original Devise API - not sure why it must be overwritten but it should be kept public to ensure this works.