### PR TITLE
Fixes connection_config deprecation warning

### DIFF
--- a/lib/graphql_devise/concerns/controller_methods.rb
+++ b/lib/graphql_devise/concerns/controller_methods.rb
@@ -90,7 +90,7 @@ module GraphqlDevise
       end
 
       def find_resource(field, value)
-        if resource_class.try(:connection_config).try(:[], :adapter).try(:include?, 'mysql')
+        if resource_class.connection.adapter_name.downcase.include?('mysql')
           # fix for mysql default case insensitivity
           resource_class.where("BINARY #{field} = ? AND provider= ?", value, provider).first
         elsif Gem::Version.new(DeviseTokenAuth::VERSION) < Gem::Version.new('1.1.0')


### PR DESCRIPTION
Fixes https://github.com/rails/rails/pull/38005

`DEPRECATION WARNING: connection_config is deprecated and will be removed from Rails 6.2 (Use connection_db_config instead)`