### PR TITLE
Allow setting current resource in tests

### DIFF
--- a/lib/graphql_devise/schema_plugin.rb
+++ b/lib/graphql_devise/schema_plugin.rb
@@ -43,18 +43,16 @@ module GraphqlDevise
       controller     = context[:controller]
       resource_names = Array(context[:resource_name])
 
-      if context[:current_resource].blank?
-        context[:current_resource] = resource_names.find do |resource_name|
-          unless Devise.mappings.key?(resource_name)
-            raise(
-              GraphqlDevise::Error,
-              "Invalid resource_name `#{resource_name}` provided to `graphql_context`. Possible values are: #{Devise.mappings.keys}."
-            )
-          end
-
-          found = controller.set_resource_by_token(resource_name)
-          break found if found
+      context[:current_resource] ||= resource_names.find do |resource_name|
+        unless Devise.mappings.key?(resource_name)
+          raise(
+            GraphqlDevise::Error,
+            "Invalid resource_name `#{resource_name}` provided to `graphql_context`. Possible values are: #{Devise.mappings.keys}."
+          )
         end
+
+        found = controller.set_resource_by_token(resource_name)
+        break found if found
       end
 
       context

--- a/lib/graphql_devise/schema_plugin.rb
+++ b/lib/graphql_devise/schema_plugin.rb
@@ -40,18 +40,21 @@ module GraphqlDevise
     private
 
     def set_current_resource(context)
-      controller                 = context[:controller]
-      resource_names             = Array(context[:resource_name])
-      context[:current_resource] = resource_names.find do |resource_name|
-        unless Devise.mappings.key?(resource_name)
-          raise(
-            GraphqlDevise::Error,
-            "Invalid resource_name `#{resource_name}` provided to `graphql_context`. Possible values are: #{Devise.mappings.keys}."
-          )
-        end
+      controller     = context[:controller]
+      resource_names = Array(context[:resource_name])
 
-        found = controller.set_resource_by_token(resource_name)
-        break found if found
+      if context[:current_resource].blank?
+        context[:current_resource] = resource_names.find do |resource_name|
+          unless Devise.mappings.key?(resource_name)
+            raise(
+              GraphqlDevise::Error,
+              "Invalid resource_name `#{resource_name}` provided to `graphql_context`. Possible values are: #{Devise.mappings.keys}."
+            )
+          end
+
+          found = controller.set_resource_by_token(resource_name)
+          break found if found
+        end
       end
 
       context

--- a/spec/graphql/user_queries_spec.rb
+++ b/spec/graphql/user_queries_spec.rb
@@ -1,0 +1,149 @@
+
+require 'rails_helper'
+
+RSpec.describe 'Sign Up process' do
+  include_context 'with graphql schema test'
+
+  let(:schema) { DummySchema }
+  let(:user)   { create(:user, :confirmed) }
+
+  describe 'publicField' do
+    let(:query) do
+      <<-GRAPHQL
+        query {
+          publicField
+        }
+      GRAPHQL
+    end
+
+    context 'when using a regular schema' do
+      it 'does not require authentication' do
+        expect(response[:data][:publicField]).to eq('Field does not require authentication')
+      end
+    end
+  end
+
+  describe 'privateField' do
+    let(:query) do
+      <<-GRAPHQL
+        query {
+          privateField
+        }
+      GRAPHQL
+    end
+
+    context 'when using a regular schema' do
+      context 'when user is authenticated' do
+        let(:resource) { user }
+
+        it 'allows to perform the query' do
+          expect(response[:data][:privateField]).to eq('Field will always require authentication')
+        end
+
+        context 'when using a SchemaUser' do
+          let(:resource) { create(:schema_user, :confirmed) }
+
+          it 'allows to perform the query' do
+            expect(response[:data][:privateField]).to eq('Field will always require authentication')
+          end
+        end
+      end
+
+      context 'when user is not authenticated' do
+        it 'returns a must sign in error' do
+          expect(response[:errors]).to contain_exactly(
+            hash_including(
+              message:    'privateField field requires authentication',
+              extensions: { code: 'AUTHENTICATION_ERROR' }
+            )
+          )
+        end
+      end
+    end
+
+    context 'when using an interpreter schema' do
+      let(:schema) { InterpreterSchema }
+
+      context 'when user is authenticated' do
+        let(:resource) { user }
+
+        it 'allows to perform the query' do
+          expect(response[:data][:privateField]).to eq('Field will always require authentication')
+        end
+      end
+
+      context 'when user is not authenticated' do
+        it 'returns a must sign in error' do
+          expect(response[:errors]).to contain_exactly(
+            hash_including(
+              message:    'privateField field requires authentication',
+              extensions: { code: 'AUTHENTICATION_ERROR' }
+            )
+          )
+        end
+      end
+    end
+  end
+
+  describe 'user' do
+    let(:query) do
+      <<-GRAPHQL
+        query {
+          user(id: #{user.id}) {
+            id
+            email
+          }
+        }
+      GRAPHQL
+    end
+
+    context 'when using a regular schema' do
+      context 'when user is authenticated' do
+        let(:resource) { user }
+
+        it 'allows to perform the query' do
+          expect(response[:data][:user]).to match(
+            email: user.email,
+            id:    user.id
+          )
+        end
+      end
+
+      context 'when user is not authenticated' do
+        it 'returns a must sign in error' do
+          expect(response[:errors]).to contain_exactly(
+            hash_including(
+              message: 'user field requires authentication',
+              extensions: { code: 'AUTHENTICATION_ERROR' }
+            )
+          )
+        end
+      end
+    end
+
+    context 'when using an interpreter schema' do
+      let(:schema) { InterpreterSchema }
+
+      context 'when user is authenticated' do
+        let(:resource) { user }
+
+        it 'allows to perform the query' do
+          expect(response[:data][:user]).to match(
+            email: user.email,
+            id:    user.id
+          )
+        end
+      end
+
+      context 'when user is not authenticated' do
+        # Interpreter schema fields are public unless specified otherwise (plugin setting)
+        it 'allows to perform the query' do
+          expect(response[:data][:user]).to match(
+            email: user.email,
+            id:    user.id
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/graphql/user_queries_spec.rb
+++ b/spec/graphql/user_queries_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe 'Sign Up process' do
+RSpec.describe 'Users controller specs' do
   include_context 'with graphql schema test'
 
   let(:schema)          { DummySchema }
@@ -58,12 +58,6 @@ RSpec.describe 'Sign Up process' do
           end
         end
       end
-
-      context 'when user is not authenticated' do
-        it 'returns a must sign in error' do
-          expect(response[:errors]).to contain_exactly(hash_including(**private_error))
-        end
-      end
     end
 
     context 'when using an interpreter schema' do
@@ -74,12 +68,6 @@ RSpec.describe 'Sign Up process' do
 
         it 'allows to perform the query' do
           expect(response[:data][:privateField]).to eq(private_message)
-        end
-      end
-
-      context 'when user is not authenticated' do
-        it 'returns a must sign in error' do
-          expect(response[:errors]).to contain_exactly(hash_including(**private_error))
         end
       end
     end
@@ -104,14 +92,6 @@ RSpec.describe 'Sign Up process' do
 
         it 'allows to perform the query' do
           expect(response[:data][:user]).to match(**user_data)
-        end
-      end
-
-      context 'when user is not authenticated' do
-        let(:field) { 'user' }
-
-        it 'returns a must sign in error' do
-          expect(response[:errors]).to contain_exactly(hash_including(**private_error))
         end
       end
     end

--- a/spec/requests/user_controller_spec.rb
+++ b/spec/requests/user_controller_spec.rb
@@ -31,15 +31,6 @@ RSpec.describe "Integrations with the user's controller" do
         expect(json_response[:data][:publicField]).to eq('Field does not require authentication')
       end
     end
-
-    context 'when using the failing route' do
-      it 'raises an invalid resource_name error' do
-        expect { post_request('/api/v1/failing') }.to raise_error(
-          GraphqlDevise::Error,
-          'Invalid resource_name `fail` provided to `graphql_context`. Possible values are: [:user, :admin, :guest, :users_customer, :schema_user].'
-        )
-      end
-    end
   end
 
   describe 'privateField' do
@@ -74,6 +65,15 @@ RSpec.describe "Integrations with the user's controller" do
         it 'returns a must sign in error' do
           expect(json_response[:errors]).to contain_exactly(
             hash_including(message: 'privateField field requires authentication', extensions: { code: 'AUTHENTICATION_ERROR' })
+          )
+        end
+      end
+
+      context 'when using the failing route' do
+        it 'raises an invalid resource_name error' do
+          expect { post_request('/api/v1/failing') }.to raise_error(
+            GraphqlDevise::Error,
+            'Invalid resource_name `fail` provided to `graphql_context`. Possible values are: [:user, :admin, :guest, :users_customer, :schema_user].'
           )
         end
       end

--- a/spec/support/contexts/schema_test.rb
+++ b/spec/support/contexts/schema_test.rb
@@ -1,8 +1,11 @@
 RSpec.shared_context 'with graphql schema test' do
-  let(:variables)  { {} }
-  let(:resource)   { nil }
-  let(:controller) { instance_double(GraphqlDevise::GraphqlController) }
-  let(:context)    { { current_resource: resource, controller: controller } }
+  let(:variables)      { {} }
+  let(:resource_names) { [] }
+  let(:resource)       { nil }
+  let(:controller)     { instance_double(GraphqlDevise::GraphqlController) }
+  let(:context) do
+    { current_resource: resource, controller: controller, resource_name: resource_names }
+  end
   let(:response) do
     schema.execute(query, context: context, variables: variables).deep_symbolize_keys
   end

--- a/spec/support/contexts/schema_test.rb
+++ b/spec/support/contexts/schema_test.rb
@@ -1,0 +1,15 @@
+RSpec.shared_context 'with graphql schema test' do
+  let(:variables)  { {} }
+  let(:resource)   { nil }
+  let(:controller) { instance_double(Api::V1::GraphqlController) }
+  let(:context)    { { current_resource: resource, controller: controller } }
+  let(:response) do
+    schema.execute(query, context: context, variables: variables).deep_symbolize_keys
+  end
+
+  # before do
+  #   allow_any_instance_of(GraphqlDevise::Mutations::Login).to receive(:set_auth_headers)
+  #   allow(controller).to receive(:request).and_return(request)
+  #   # allow(controller).to receive(:response).and_return(response)
+  # end
+end

--- a/spec/support/contexts/schema_test.rb
+++ b/spec/support/contexts/schema_test.rb
@@ -1,15 +1,9 @@
 RSpec.shared_context 'with graphql schema test' do
   let(:variables)  { {} }
   let(:resource)   { nil }
-  let(:controller) { instance_double(Api::V1::GraphqlController) }
+  let(:controller) { instance_double(GraphqlDevise::GraphqlController) }
   let(:context)    { { current_resource: resource, controller: controller } }
   let(:response) do
     schema.execute(query, context: context, variables: variables).deep_symbolize_keys
   end
-
-  # before do
-  #   allow_any_instance_of(GraphqlDevise::Mutations::Login).to receive(:set_auth_headers)
-  #   allow(controller).to receive(:request).and_return(request)
-  #   # allow(controller).to receive(:response).and_return(response)
-  # end
 end

--- a/spec/support/contexts/schema_test.rb
+++ b/spec/support/contexts/schema_test.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 RSpec.shared_context 'with graphql schema test' do
   let(:variables)      { {} }
-  let(:resource_names) { [] }
+  let(:resource_names) { [:user] }
   let(:resource)       { nil }
   let(:controller)     { instance_double(GraphqlDevise::GraphqlController) }
   let(:context) do


### PR DESCRIPTION
Allows setting `current_resource` on specs using `with graphql schema test` shared context


Closes #138 

