### PR TITLE
Fix "confirm_account" resolver return.

### DIFF
--- a/lib/graphql_devise/resolvers/confirm_account.rb
+++ b/lib/graphql_devise/resolvers/confirm_account.rb
@@ -4,34 +4,37 @@ module GraphqlDevise
   module Resolvers
     class ConfirmAccount < Base
       argument :confirmation_token, String, required: true
-      argument :redirect_url,       String, required: true
+      argument :redirect_url,       String, required: false
 
-      def resolve(confirmation_token:, redirect_url:)
-        check_redirect_url_whitelist!(redirect_url)
-
+      def resolve(confirmation_token:, redirect_url: nil)
         resource = resource_class.confirm_by_token(confirmation_token)
-
+  
         if resource.errors.empty?
           yield resource if block_given?
-
-          redirect_header_options = { account_confirmation_success: true }
-
-          redirect_to_link = if controller.signed_in?(resource_name)
-            url = resource.build_auth_url(
-              redirect_url,
-              redirect_headers(
-                client_and_token(resource.create_token),
-                redirect_header_options
+  
+          if redirect_url.present?
+            check_redirect_url_whitelist!(redirect_url)
+            redirect_header_options = { account_confirmation_success: true }
+  
+            redirect_to_link = if controller.signed_in?(resource_name)
+              url = resource.build_auth_url(
+                redirect_url,
+                redirect_headers(
+                  client_and_token(resource.create_token),
+                  redirect_header_options
+                )
               )
-            )
-            resource.save!
-
-            url
-          else
-            DeviseTokenAuth::Url.generate(redirect_url, redirect_header_options)
+              resource.save!
+  
+              url
+            else
+              DeviseTokenAuth::Url.generate(redirect_url, redirect_header_options)
+            end
+  
+            controller.redirect_to(redirect_to_link)
+            return
           end
-
-          controller.redirect_to(redirect_to_link)
+  
           resource
         else
           raise_user_error(I18n.t('graphql_devise.confirmations.invalid_token'))

--- a/lib/graphql_devise/resolvers/confirm_account.rb
+++ b/lib/graphql_devise/resolvers/confirm_account.rb
@@ -32,7 +32,7 @@ module GraphqlDevise
           end
 
           controller.redirect_to(redirect_to_link)
-          { authenticatable: resource }
+          resource
         else
           raise_user_error(I18n.t('graphql_devise.confirmations.invalid_token'))
         end


### PR DESCRIPTION
The "confirm_account" resolver should return the _resource_ object instead of _{ authenticatable: resource }_ the same way as the "check_password_token" resolver.

Otherwise it is impossible to request fields for that query, since you would get the following error:

"errors"=>[{"message"=>"Cannot return null for non-nullable field User.email"}]