### PR TITLE
Fix confirm account resolver return value

### DIFF
--- a/lib/graphql_devise/resolvers/confirm_account.rb
+++ b/lib/graphql_devise/resolvers/confirm_account.rb
@@ -32,7 +32,7 @@ module GraphqlDevise
           end
 
           controller.redirect_to(redirect_to_link)
-          { authenticatable: resource }
+          resource
         else
           raise_user_error(I18n.t('graphql_devise.confirmations.invalid_token'))
         end


### PR DESCRIPTION
For this query, having the schema fail as the wrong object was returned from the resolve method didn't really have an effect as the controller will redirect anyway. Adding this just so the resolver is in a "correct state"