### PR TITLE
Allow checking of authenticaded resource via callable object

### DIFF
--- a/lib/graphql_devise/schema_plugin.rb
+++ b/lib/graphql_devise/schema_plugin.rb
@@ -46,7 +46,7 @@ module GraphqlDevise
 
       if auth_required && !(public_introspection && introspection_field?(field))
         context = set_current_resource(context)
-        raise_on_missing_resource(context, field)
+        raise_on_missing_resource(context, field, auth_required)
       end
 
       yield
@@ -75,8 +75,12 @@ module GraphqlDevise
       context
     end
 
-    def raise_on_missing_resource(context, field)
+    def raise_on_missing_resource(context, field, auth_required)
       @unauthenticated_proc.call(field.name) if context[:current_resource].blank?
+
+      if auth_required.respond_to?(:call) && !auth_required.call(context[:current_resource])
+        @unauthenticated_proc.call(field.name)
+      end
     end
 
     def context_from_data(trace_data)

--- a/spec/dummy/app/graphql/types/query_type.rb
+++ b/spec/dummy/app/graphql/types/query_type.rb
@@ -5,6 +5,7 @@ module Types
     field :user, resolver: Resolvers::UserShow
     field :public_field, String, null: false, authenticate: false
     field :private_field, String, null: false, authenticate: true
+    field :vip_field, String, null: false, authenticate: ->(user) { user.is_a?(User) && user.vip? }
 
     def public_field
       'Field does not require authentication'
@@ -12,6 +13,10 @@ module Types
 
     def private_field
       'Field will always require authentication'
+    end
+
+    def vip_field
+      'Field available only for VIP Users'
     end
   end
 end

--- a/spec/dummy/db/migrate/20210516211417_add_vip_to_users.rb
+++ b/spec/dummy/db/migrate/20210516211417_add_vip_to_users.rb
@@ -1,0 +1,5 @@
+class AddVipToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :vip, :boolean, null: false, default: false
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -2,15 +2,15 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_23_003142) do
+ActiveRecord::Schema.define(version: 2021_05_16_211417) do
 
   create_table "admins", force: :cascade do |t|
     t.string "provider", default: "email", null: false
@@ -105,6 +105,7 @@ ActiveRecord::Schema.define(version: 2020_06_23_003142) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "auth_available", default: true, null: false
+    t.boolean "vip", default: false, null: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true


### PR DESCRIPTION
With this change you can now use a custom callable object to check for additional conditions on the authenticated resource. Before we would only check for the presence of `context[:current_resource]` after token authentication. Now you can do something like this:
```ruby
field :admin_field, String, null: false, authenticate: ->(user) { user.admin? }
```
This does not intend to replace a more complete authorization framework, but just support a bit more complex authentication conditions that I can imagine would work for most fields.

I would still advise to look into gems like [graphql-guard](https://github.com/exAspArk/graphql-guard) as a more complete authorization gem in GraphQL. Also, the [GraphQL gem](https://github.com/rmosolgo/graphql-ruby) has premium support for authorization and a [basic API](https://graphql-ruby.org/mutations/mutation_authorization.html#can-this-user-perform-this-action) that you could use for this purpose.

Resolves #118 