### PR TITLE
Deprecate mutations and queries that required a redirect

### DIFF
--- a/lib/graphql_devise/default_operations/mutations.rb
+++ b/lib/graphql_devise/default_operations/mutations.rb
@@ -18,13 +18,13 @@ module GraphqlDevise
     MUTATIONS = {
       login:                           { klass: GraphqlDevise::Mutations::Login, authenticatable: true },
       logout:                          { klass: GraphqlDevise::Mutations::Logout, authenticatable: true },
-      sign_up:                         { klass: GraphqlDevise::Mutations::SignUp, authenticatable: true },
+      sign_up:                         { klass: GraphqlDevise::Mutations::SignUp, authenticatable: true, deprecation_reason: 'use register instead' },
       register:                        { klass: GraphqlDevise::Mutations::Register, authenticatable: true },
       update_password:                 { klass: GraphqlDevise::Mutations::UpdatePassword, authenticatable: true },
       update_password_with_token:      { klass: GraphqlDevise::Mutations::UpdatePasswordWithToken, authenticatable: true },
       send_password_reset:             { klass: GraphqlDevise::Mutations::SendPasswordReset, authenticatable: false },
       send_password_reset_with_token:  { klass: GraphqlDevise::Mutations::SendPasswordResetWithToken, authenticatable: false },
-      resend_confirmation:             { klass: GraphqlDevise::Mutations::ResendConfirmation, authenticatable: false },
+      resend_confirmation:             { klass: GraphqlDevise::Mutations::ResendConfirmation, authenticatable: false, deprecation_reason: 'use resendConfirmationWithToken instead' },
       resend_confirmation_with_token:  { klass: GraphqlDevise::Mutations::ResendConfirmationWithToken, authenticatable: false },
       confirm_registration_with_token: { klass: GraphqlDevise::Mutations::ConfirmRegistrationWithToken, authenticatable: true }
     }.freeze

--- a/lib/graphql_devise/default_operations/resolvers.rb
+++ b/lib/graphql_devise/default_operations/resolvers.rb
@@ -7,8 +7,8 @@ require 'graphql_devise/resolvers/confirm_account'
 module GraphqlDevise
   module DefaultOperations
     QUERIES = {
-      confirm_account:      { klass: GraphqlDevise::Resolvers::ConfirmAccount },
-      check_password_token: { klass: GraphqlDevise::Resolvers::CheckPasswordToken }
+      confirm_account:      { klass: GraphqlDevise::Resolvers::ConfirmAccount, deprecation_reason: 'use the new confirmation flow as it does not require this query anymore' },
+      check_password_token: { klass: GraphqlDevise::Resolvers::CheckPasswordToken, deprecation_reason: 'use the new password reset flow as it does not require this query anymore' }
     }.freeze
   end
 end

--- a/lib/graphql_devise/mount_method/operation_preparers/default_operation_preparer.rb
+++ b/lib/graphql_devise/mount_method/operation_preparers/default_operation_preparer.rb
@@ -17,7 +17,7 @@ module GraphqlDevise
           @selected_operations.except(*@custom_keys).each_with_object({}) do |(action, operation_info), result|
             mapped_action = "#{mapping_name}_#{action}"
             operation     = operation_info[:klass]
-            options       = operation_info.except(:klass)
+            options       = operation_info.except(:klass, :deprecation_reason)
 
             result[mapped_action.to_sym] = [
               OperationPreparers::GqlNameSetter.new(mapped_action),

--- a/lib/graphql_devise/mount_method/operation_sanitizer.rb
+++ b/lib/graphql_devise/mount_method/operation_sanitizer.rb
@@ -18,12 +18,23 @@ module GraphqlDevise
       end
 
       def call
-        if @only.present?
+        operations = if @only.present?
           @default.slice(*@only)
         elsif @skipped.present?
           @default.except(*@skipped)
         else
           @default
+        end
+
+        operations.each do |operation, values|
+          if values[:deprecation_reason].present?
+            ActiveSupport::Deprecation.warn(<<-DEPRECATION.strip_heredoc, caller)
+              `#{operation}` is deprecated and will be removed in a future version of this gem.
+              #{values[:deprecation_reason]}
+
+              You can supress this message by skipping `#{operation}` on your ResourceLoader.
+            DEPRECATION
+          end
         end
       end
     end

--- a/spec/services/mount_method/operation_sanitizer_spec.rb
+++ b/spec/services/mount_method/operation_sanitizer_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe GraphqlDevise::MountMethod::OperationSanitizer do
     context 'when the operations passed are mutations' do
       let(:skipped)  { [] }
       let(:only)     { [] }
-      let(:default)  { { operation1: op_class1, operation2: op_class2 } }
+      let(:default)  { { operation1: { klass: op_class1 }, operation2: { klass: op_class2 } } }
 
       context 'when no other option besides default is passed' do
         it { is_expected.to eq(default) }
@@ -22,13 +22,13 @@ RSpec.describe GraphqlDevise::MountMethod::OperationSanitizer do
       context 'when there are only operations' do
         let(:only) { [:operation1] }
 
-        it { is_expected.to eq(operation1: op_class1) }
+        it { is_expected.to eq(operation1: { klass: op_class1 }) }
       end
 
       context 'when there are skipped operations' do
         let(:skipped) { [:operation2] }
 
-        it { is_expected.to eq(operation1: op_class1) }
+        it { is_expected.to eq(operation1: { klass: op_class1 }) }
       end
     end
   end


### PR DESCRIPTION
Deprecated all queries that required a controller redirect in favor of the new alternatives:

- sign_up -> register
- resend_confirmation -> resend_confirmation_with_token
- confirm_account -> new flow doesn't require this query
- check_password_token -> new flow doesn't require this query