### PR TITLE
Fixes #192 - Update context upon login

### DIFF
--- a/lib/graphql_devise/mutations/login.rb
+++ b/lib/graphql_devise/mutations/login.rb
@@ -24,6 +24,8 @@ module GraphqlDevise
 
           yield resource if block_given?
 
+          context[:current_resource] = resource if context[:current_resource].nil?
+
           { authenticatable: resource, credentials: new_headers }
         elsif resource && !active_for_authentication?(resource)
           if locked?(resource)


### PR DESCRIPTION
If using [Object Authorization](https://graphql-ruby.org/authorization/authorization.html#object-authorization)
that relies on `context[:current_resource]` it is not possible to query
for data on the authenticatable object since `context[:current_user]` is
`nil` after logging in since this is set at the controller level.

This commit fixes this by setting `context[:current_resource]` to
`resource` _if_ `context[:current_resource]` is `nil` (as the
implementation may override this already).

GitHub issue - https://github.com/graphql-devise/graphql_devise/issues/192