### PR TITLE
Drop support for ruby 2.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,6 @@ workflows:
           matrix:
             parameters:
               ruby-version:
-                - '2.2'
                 - '2.3'
                 - '2.4'
                 - '2.5'
@@ -69,14 +68,6 @@ workflows:
                 - gemfiles/rails6.1_graphql1.11.gemfile
                 - gemfiles/rails6.1_graphql1.12.gemfile
             exclude:
-              - ruby-version: '2.2'
-                gemfile: gemfiles/rails6.0_graphql1.11.gemfile
-              - ruby-version: '2.2'
-                gemfile: gemfiles/rails6.0_graphql1.12.gemfile
-              - ruby-version: '2.2'
-                gemfile: gemfiles/rails6.1_graphql1.11.gemfile
-              - ruby-version: '2.2'
-                gemfile: gemfiles/rails6.1_graphql1.12.gemfile
               - ruby-version: '2.3'
                 gemfile: gemfiles/rails6.0_graphql1.11.gemfile
               - ruby-version: '2.3'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,11 +1,10 @@
-require: rubocop-rspec
-require: rubocop-performance
-
-Rails:
-  Enabled: true
+require:
+  - rubocop-rspec
+  - rubocop-performance
+  - rubocop-rails
 
 AllCops:
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.3
   DisplayCopNames: true
   Exclude:
     - bin/**/*
@@ -82,7 +81,7 @@ Style/FrozenStringLiteralComment:
 Style/StringMethods:
   Enabled: true
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 120
 
 Metrics/MethodLength:
@@ -91,16 +90,16 @@ Metrics/MethodLength:
 Metrics/BlockLength:
   Enabled: false
 
-Layout/AlignHash:
+Layout/HashAlignment:
   EnforcedColonStyle: table
 
-Layout/AlignParameters:
+Layout/ParameterAlignment:
   EnforcedStyle: with_fixed_indentation
   SupportedStyles:
     - with_first_parameter
     - with_fixed_indentation
 
-Lint/EndAlignment:
+Layout/EndAlignment:
   EnforcedStyleAlignWith: variable
   SupportedStylesAlignWith:
     - keyword

--- a/graphql_devise.gemspec
+++ b/graphql_devise.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
     `git ls-files -z`.split("\x0").select { |f| f.match(%r{^spec/}) }
   end
 
-  spec.required_ruby_version = '>= 2.2.0'
+  spec.required_ruby_version = '>= 2.3.0'
 
   spec.add_dependency 'devise_token_auth', '>= 0.1.43', '< 2.0'
   spec.add_dependency 'graphql', '>= 1.8', '< 1.13.0'
@@ -41,8 +41,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'rake', '>= 12.3.3'
   spec.add_development_dependency 'rspec-rails', '~> 4.0'
-  spec.add_development_dependency 'rubocop', '0.68.1'
-  spec.add_development_dependency 'rubocop-performance'
-  spec.add_development_dependency 'rubocop-rspec'
+  spec.add_development_dependency 'rubocop', '< 0.82.0'
+  spec.add_development_dependency 'rubocop-performance', '< 1.6.0'
+  spec.add_development_dependency 'rubocop-rails', '< 2.6.0'
+  spec.add_development_dependency 'rubocop-rspec', '< 1.39.0'
   spec.add_development_dependency 'sqlite3', '~> 1.3'
 end


### PR DESCRIPTION
- Drops support for Ruby 2.2 as DTA did the same in https://github.com/lynndylanhurley/devise_token_auth/pull/1495
- Updated rubocop dependency requirements to support max version before dropping support for ruby 2.3.
- Rubocop configuration was inherited from another project and never taken care of, we should try to cleanup the config and fix offenses in the future

Resolves #195 