### PR TITLE
Silence graphql_definition deprecation warning before suporting GQL 2.0

### DIFF
--- a/lib/graphql_devise/schema_plugin.rb
+++ b/lib/graphql_devise/schema_plugin.rb
@@ -113,7 +113,7 @@ module GraphqlDevise
       auth_required = if trace_data[:context]
         field.metadata[:authenticate]
       else
-        field.graphql_definition.metadata[:authenticate]
+        field.graphql_definition(silence_deprecation_warning: true).metadata[:authenticate]
       end
 
       auth_required.nil? ? @authenticate_default : auth_required


### PR DESCRIPTION
Silences `graphql_definition` deprecation warning. Nothing users of this gem can do about it before we release v1.0 that should include support for GraphQL 2.0.

Related to https://github.com/graphql-devise/graphql_devise/issues/212#issuecomment-1061671717