### PR TITLE
Resolve Zeitwerk generators warning

### DIFF
--- a/lib/graphql_devise.rb
+++ b/lib/graphql_devise.rb
@@ -15,7 +15,7 @@ loader = Zeitwerk::Loader.for_gem
 
 loader.collapse("#{__dir__}/graphql_devise/concerns")
 loader.collapse("#{__dir__}/graphql_devise/errors")
-loader.collapse("#{__dir__}/generators")
+loader.ignore("#{__dir__}/generators")
 
 loader.inflector.inflect('error_codes' => 'ERROR_CODES')
 loader.inflector.inflect('supported_options' => 'SUPPORTED_OPTIONS')


### PR DESCRIPTION
Zeitwerk has the following warning:

```
WARNING: Zeitwerk defines the constant Generators after the directory

    /Users/USER/OpenSource/graphql_devise/lib/generators

To prevent that, please configure the loader to ignore it:

    loader.ignore("#{__dir__}/generators")

Otherwise, there is a flag to silence this warning:

    Zeitwerk::Loader.for_gem(warn_on_extra_files: false)
```

The loader is already collapsing the generators directory on line 18 of `lib/graphql_devise.rb`, however it seems like if Zeitwerk needs to fully ignore it since it shares the namespace with the ruby Generators module.

Relevant details on Zeitwerk [for_gem](https://github.com/fxn/zeitwerk#for_gem)

> Loaders returned by Zeitwerk::Loader.for_gem issue warnings if lib has extra Ruby files or directories.
>For example, if the gem has Rails generators under lib/generators, by convention that directory defines a Generators Ruby >module. If generators is just a container for non-autoloadable code and templates, not acting as a project namespace, you >need to setup things accordingly.
