### PR TITLE
Support DTA's authorization header

### DIFF
--- a/lib/graphql_devise/types/credential_type.rb
+++ b/lib/graphql_devise/types/credential_type.rb
@@ -3,11 +3,12 @@
 module GraphqlDevise
   module Types
     class CredentialType < BaseType
-      field :access_token, String, null: false
-      field :uid,          String, null: false
-      field :token_type,   String, null: false
-      field :client,       String, null: false
-      field :expiry,       Int,    null: false
+      field :access_token,  String, null: false
+      field :uid,           String, null: false
+      field :token_type,    String, null: false
+      field :client,        String, null: false
+      field :expiry,        Int,    null: false
+      field :authorization, String, null: false
 
       def access_token
         object[DeviseTokenAuth.headers_names[:"access-token"]]
@@ -27,6 +28,10 @@ module GraphqlDevise
 
       def expiry
         object[DeviseTokenAuth.headers_names[:expiry]]
+      end
+
+      def authorization
+        object[DeviseTokenAuth.headers_names[:authorization]]
       end
     end
   end

--- a/spec/requests/mutations/login_spec.rb
+++ b/spec/requests/mutations/login_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Login Requests' do
             password: "#{password}"
           ) {
             user { email name signInCount }
-            credentials { accessToken uid tokenType client expiry }
+            credentials { accessToken uid tokenType client expiry authorization }
           }
         }
       GRAPHQL
@@ -34,11 +34,12 @@ RSpec.describe 'Login Requests' do
           expect(json_response[:data][:userLogin]).to match(
             user:        { email: user.email, name: user.name, signInCount: 1 },
             credentials: {
-              accessToken: response.headers['access-token'],
-              uid:         response.headers['uid'],
-              tokenType:   response.headers['token-type'],
-              client:      response.headers['client'],
-              expiry:      response.headers['expiry'].to_i
+              accessToken:   response.headers['access-token'],
+              uid:           response.headers['uid'],
+              tokenType:     response.headers['token-type'],
+              client:        response.headers['client'],
+              expiry:        response.headers['expiry'].to_i,
+              authorization: response.headers['Authorization']
             }
           )
           expect(json_response[:errors]).to be_nil


### PR DESCRIPTION
Authorization header support was implemented in https://github.com/lynndylanhurley/devise_token_auth/pull/1534

This works in edge DTA, but seems like can't be merged until graphql_devise and DTA are properly synced