### PR TITLE
Use the class itself in the route generator instead of a string representation

### DIFF
--- a/lib/generators/graphql_devise/install_generator.rb
+++ b/lib/generators/graphql_devise/install_generator.rb
@@ -38,7 +38,7 @@ module GraphqlDevise
       if options['mount'] != 'separate_route'
         gsub_file(routes_file, /^\s+#{Regexp.escape(dta_route + "\n")}/i, '')
       else
-        gem_route = "mount_graphql_devise_for '#{user_class}', at: '#{mount_path}'"
+        gem_route = "mount_graphql_devise_for #{user_class}, at: '#{mount_path}'"
 
         if file_contains_str?(routes_file, gem_route)
           gsub_file(routes_file, /^\s+#{Regexp.escape(dta_route + "\n")}/i, '')

--- a/spec/generators/graphql_devise/install_generator_spec.rb
+++ b/spec/generators/graphql_devise/install_generator_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe GraphqlDevise::InstallGenerator, type: :generator do
     let(:args) { [] }
 
     it 'creates and updated required files' do
-      assert_file 'config/routes.rb', /^\s{2}mount_graphql_devise_for 'User', at: 'graphql_auth'/
+      assert_file 'config/routes.rb', /^\s{2}mount_graphql_devise_for User, at: 'graphql_auth'/
       expect(routes_content).not_to match(dta_route)
 
       assert_file 'config/initializers/devise.rb'
@@ -60,7 +60,7 @@ RSpec.describe GraphqlDevise::InstallGenerator, type: :generator do
     let(:args) { %w[Admin api] }
 
     it 'creates and updated required files' do
-      assert_file 'config/routes.rb', /^\s{2}mount_graphql_devise_for 'Admin', at: 'api'/
+      assert_file 'config/routes.rb', /^\s{2}mount_graphql_devise_for Admin, at: 'api'/
       expect(routes_content).not_to match(dta_route)
 
       assert_file 'config/initializers/devise.rb'


### PR DESCRIPTION
The generator creates the model class as a string in config/routes.rb.
This commit modifies the generator so that the model is used as a class in
config/routes.rb.

This PR fixes #235 