### PR TITLE
Test current_resource is set on public fields

### DIFF
--- a/spec/dummy/app/graphql/types/query_type.rb
+++ b/spec/dummy/app/graphql/types/query_type.rb
@@ -10,7 +10,11 @@ module Types
     field :vip_field, String, null: false, authenticate: ->(user) { user.is_a?(User) && user.vip? }
 
     def public_field
-      'Field does not require authentication'
+      if context[:current_resource]
+        "Authenticated user on public field: #{context[:current_resource].email}"
+      else
+        'Field does not require authentication'
+      end
     end
 
     def private_field

--- a/spec/requests/user_controller_spec.rb
+++ b/spec/requests/user_controller_spec.rb
@@ -30,6 +30,16 @@ RSpec.describe "Integrations with the user's controller" do
       it 'does not require authentication' do
         expect(json_response[:data][:publicField]).to eq('Field does not require authentication')
       end
+
+      context 'when user sends authentication headers anyway' do
+        let(:headers) { user.create_new_auth_token }
+
+        it 'sets current resource in the context' do
+          expect(json_response[:data][:publicField]).to eq(
+            "Authenticated user on public field: #{user.email}"
+          )
+        end
+      end
     end
 
     context 'when using an interpreter schema' do
@@ -37,6 +47,16 @@ RSpec.describe "Integrations with the user's controller" do
 
       it 'does not require authentication' do
         expect(json_response[:data][:publicField]).to eq('Field does not require authentication')
+      end
+
+      context 'when user sends authentication headers anyway' do
+        let(:headers) { user.create_new_auth_token }
+
+        it 'sets current resource in the context' do
+          expect(json_response[:data][:publicField]).to eq(
+            "Authenticated user on public field: #{user.email}"
+          )
+        end
       end
     end
   end


### PR DESCRIPTION
Resolves #227 

@NathanielAwoke I added this test to make sure `current_resource` is set even for fields that don't require authentication if you send the proper params. Can you confirm if you are still not getting current_resource on your context?