### PR TITLE
Allow defining a custom raise_user_error_list method

### DIFF
--- a/lib/graphql_devise/concerns/controller_methods.rb
+++ b/lib/graphql_devise/concerns/controller_methods.rb
@@ -16,8 +16,8 @@ module GraphqlDevise
       raise UserError, message
     end
 
-    def raise_user_error_list(message, errors:)
-      raise DetailedUserError.new(message, errors: errors)
+    def raise_user_error_list(message, resource:)
+      raise DetailedUserError.new(message, errors: resource.errors.full_messages)
     end
 
     def remove_resource

--- a/lib/graphql_devise/mutations/register.rb
+++ b/lib/graphql_devise/mutations/register.rb
@@ -45,7 +45,7 @@ module GraphqlDevise
           resource.try(:clean_up_passwords)
           raise_user_error_list(
             I18n.t('graphql_devise.registration_failed'),
-            errors: resource.errors.full_messages
+            resource: resource
           )
         end
       end

--- a/lib/graphql_devise/mutations/send_password_reset_with_token.rb
+++ b/lib/graphql_devise/mutations/send_password_reset_with_token.rb
@@ -26,7 +26,7 @@ module GraphqlDevise
           if resource.errors.empty?
             { message: I18n.t('graphql_devise.passwords.send_instructions') }
           else
-            raise_user_error_list(I18n.t('graphql_devise.invalid_resource'), errors: resource.errors.full_messages)
+            raise_user_error_list(I18n.t('graphql_devise.invalid_resource'), resource: resource)
           end
         else
           raise_user_error(I18n.t('graphql_devise.user_not_found'))

--- a/lib/graphql_devise/mutations/update_password_with_token.rb
+++ b/lib/graphql_devise/mutations/update_password_with_token.rb
@@ -29,7 +29,7 @@ module GraphqlDevise
         else
           raise_user_error_list(
             I18n.t('graphql_devise.passwords.update_password_error'),
-            errors: resource.errors.full_messages
+            resource: resource
           )
         end
       end

--- a/spec/dummy/app/graphql/mutations/register_confirmed_user.rb
+++ b/spec/dummy/app/graphql/mutations/register_confirmed_user.rb
@@ -17,7 +17,7 @@ module Mutations
       else
         raise_user_error_list(
           'Custom registration failed',
-          errors: user.errors.full_messages
+          resource: user
         )
       end
     end


### PR DESCRIPTION
By changing the arguments `raise_user_error_list` receives, we allow users to customize the errors they raise
by simply passing the failed resource to the method

Resolves #262