### PR TITLE
Use new trace interface, remove deprecation warnings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
       RUBYOPT: '-rostruct'
     steps:
       - checkout
-      - run: gem install bundler -v '2.4.22'
+      - run: ruby bin/install_bundler.rb
       - run:
           name: Install dependencies
           command: bundle install
@@ -42,9 +42,6 @@ workflows:
               ruby-version:
                 - '2.7'
                 - '3.0'
-                - '3.1'
-                - '3.2'
-                - '3.3'
               gemfile:
                 - gemfiles/rails6.0_graphql1.11.gemfile
                 - gemfiles/rails6.0_graphql1.12.gemfile
@@ -64,13 +61,6 @@ workflows:
                 - gemfiles/rails7.1_graphql2.1.gemfile
                 - gemfiles/rails7.1_graphql2.2.gemfile
                 - gemfiles/rails7.1_graphql2.3.gemfile
-            exclude:
-              - ruby-version: '3.3'
-                gemfile: gemfiles/rails6.0_graphql1.11.gemfile
-              - ruby-version: '3.3'
-                gemfile: gemfiles/rails6.0_graphql1.12.gemfile
-              - ruby-version: '3.3'
-                gemfile: gemfiles/rails6.0_graphql1.13.gemfile
       - report-coverage:
           requires:
             - test

--- a/bin/install_bundler.rb
+++ b/bin/install_bundler.rb
@@ -1,0 +1,11 @@
+#!ruby
+
+ruby_version  = Gem::Version.new(RUBY_VERSION)
+
+if ruby_version < Gem::Version.new('2.6')
+  system('gem install bundler -v 2.3.27')
+elsif ruby_version >= Gem::Version.new('2.6') && ruby_version < Gem::Version.new('3.0')
+  system('gem install bundler -v 2.4.22')
+else
+  system('gem install bundler')
+end

--- a/lib/graphql_devise/field_auth_tracer.rb
+++ b/lib/graphql_devise/field_auth_tracer.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module GraphqlDevise
+  module FieldAuthTracer
+    def initialize(authenticate_default:, public_introspection:, unauthenticated_proc:, **_rest)
+      @authenticate_default = authenticate_default
+      @public_introspection = public_introspection
+      @unauthenticated_proc = unauthenticated_proc
+
+      super
+    end
+
+    def execute_field(field:, query:, ast_node:, arguments:, object:)
+      # Authenticate only root level queries
+      return super unless query.context.current_path.count == 1
+
+      auth_required = authenticate_option(field)
+
+      if auth_required && !(public_introspection && introspection_field?(field.name))
+        raise_on_missing_resource(query.context, field, auth_required)
+      end
+
+      super
+    end
+
+    private
+
+    attr_reader :public_introspection
+
+    def authenticate_option(field)
+      auth_required = field.try(:authenticate)
+
+      auth_required.nil? ? @authenticate_default : auth_required
+    end
+
+    def introspection_field?(field_name)
+      SchemaPlugin::INTROSPECTION_FIELDS.include?(field_name.downcase)
+    end
+
+    def raise_on_missing_resource(context, field, auth_required)
+      @unauthenticated_proc.call(field.name) if context[:current_resource].blank?
+
+      if auth_required.respond_to?(:call) && !auth_required.call(context[:current_resource])
+        @unauthenticated_proc.call(field.name)
+      end
+    end
+  end
+end

--- a/lib/graphql_devise/schema_plugin.rb
+++ b/lib/graphql_devise/schema_plugin.rb
@@ -19,7 +19,16 @@ module GraphqlDevise
     end
 
     def use(schema_definition)
-      schema_definition.tracer(self)
+      if Gem::Version.new(GraphQL::VERSION) >= Gem::Version.new('2.3')
+        schema_definition.trace_with(
+          FieldAuthTracer,
+          authenticate_default: @authenticate_default,
+          public_introspection: public_introspection,
+          unauthenticated_proc: @unauthenticated_proc
+        )
+      else
+        schema_definition.tracer(self)
+      end
     end
 
     def trace(event, trace_data)

--- a/spec/requests/queries/introspection_query_spec.rb
+++ b/spec/requests/queries/introspection_query_spec.rb
@@ -116,7 +116,13 @@ RSpec.describe 'Login Requests' do
 
         context 'and introspection is set to require auth' do
           before do
-            allow_any_instance_of(GraphqlDevise::SchemaPlugin).to(
+            target_class = if Gem::Version.new(GraphQL::VERSION) >= Gem::Version.new('2.3')
+              GraphqlDevise::FieldAuthTracer
+            else
+              GraphqlDevise::SchemaPlugin
+            end
+
+            allow_any_instance_of(target_class).to(
               receive(:public_introspection).and_return(false)
             )
           end


### PR DESCRIPTION
Using new module based tracing mechanism to remove deprecation warnings.

Temporarily removing newer ruby versions from the test matrix as apparently some more changes will be needed to support those versions

Resolves #273 