### PR TITLE
Fix coveralls integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  coveralls: coveralls/coveralls@1.0.6
+  coveralls: coveralls/coveralls@2.2.5
 
 jobs:
   test:
@@ -12,9 +12,8 @@ jobs:
     docker:
       - image: 'ruby:<< parameters.ruby-version >>'
     environment:
-      BUNDLE_GEMFILE: << parameters.gemfile >>
+      BUNDLE_GEMFILE: gemfiles/<< parameters.gemfile >>.gemfile
       BUNDLE_JOBS: '2'
-      COVERALLS_PARALLEL: 'true'
       EAGER_LOAD: 'true'
       RUBYOPT: '-rostruct'
     steps:
@@ -27,6 +26,13 @@ jobs:
           name: Run Specs
           command:
             bundle exec rspec
+      - coveralls/upload:
+          parallel: true
+          coverage_file: ./coverage/.resultset.json
+          coverage_format: simplecov
+          # Parallel jobs must each report a unique flag_name or Coveralls
+          # collapses them into a single job. Keep it free of slashes.
+          flag_name: ruby-<< parameters.ruby-version >>-<< parameters.gemfile >>
   report-coverage:
     docker:
       - image: 'cimg/node:22.1.0'
@@ -47,75 +53,75 @@ workflows:
                 - '3.3'
                 - '3.4'
               gemfile:
-                - gemfiles/rails7.0_graphql2.3.gemfile
-                - gemfiles/rails7.0_graphql2.4.gemfile
-                - gemfiles/rails7.1_graphql2.0.gemfile
-                - gemfiles/rails7.1_graphql2.1.gemfile
-                - gemfiles/rails7.1_graphql2.2.gemfile
-                - gemfiles/rails7.1_graphql2.3.gemfile
-                - gemfiles/rails7.1_graphql2.4.gemfile
-                - gemfiles/rails7.2_graphql2.0.gemfile
-                - gemfiles/rails7.2_graphql2.1.gemfile
-                - gemfiles/rails7.2_graphql2.2.gemfile
-                - gemfiles/rails7.2_graphql2.3.gemfile
-                - gemfiles/rails7.2_graphql2.4.gemfile
-                - gemfiles/rails7.2_graphql2.5.gemfile
-                - gemfiles/rails7.2_graphql2.6.gemfile
-                - gemfiles/rails8.0_graphql2.2.gemfile
-                - gemfiles/rails8.0_graphql2.3.gemfile
-                - gemfiles/rails8.0_graphql2.4.gemfile
-                - gemfiles/rails8.0_graphql2.5.gemfile
-                - gemfiles/rails8.0_graphql2.6.gemfile
-                - gemfiles/rails8.1_graphql2.4.gemfile
-                - gemfiles/rails8.1_graphql2.5.gemfile
-                - gemfiles/rails8.1_graphql2.6.gemfile
+                - rails7.0_graphql2.3
+                - rails7.0_graphql2.4
+                - rails7.1_graphql2.0
+                - rails7.1_graphql2.1
+                - rails7.1_graphql2.2
+                - rails7.1_graphql2.3
+                - rails7.1_graphql2.4
+                - rails7.2_graphql2.0
+                - rails7.2_graphql2.1
+                - rails7.2_graphql2.2
+                - rails7.2_graphql2.3
+                - rails7.2_graphql2.4
+                - rails7.2_graphql2.5
+                - rails7.2_graphql2.6
+                - rails8.0_graphql2.2
+                - rails8.0_graphql2.3
+                - rails8.0_graphql2.4
+                - rails8.0_graphql2.5
+                - rails8.0_graphql2.6
+                - rails8.1_graphql2.4
+                - rails8.1_graphql2.5
+                - rails8.1_graphql2.6
             exclude:
               - ruby-version: '3.0'
-                gemfile: gemfiles/rails7.2_graphql2.0.gemfile
+                gemfile: rails7.2_graphql2.0
               - ruby-version: '3.0'
-                gemfile: gemfiles/rails7.2_graphql2.1.gemfile
+                gemfile: rails7.2_graphql2.1
               - ruby-version: '3.0'
-                gemfile: gemfiles/rails7.2_graphql2.2.gemfile
+                gemfile: rails7.2_graphql2.2
               - ruby-version: '3.0'
-                gemfile: gemfiles/rails7.2_graphql2.3.gemfile
+                gemfile: rails7.2_graphql2.3
               - ruby-version: '3.0'
-                gemfile: gemfiles/rails7.2_graphql2.4.gemfile
+                gemfile: rails7.2_graphql2.4
               - ruby-version: '3.0'
-                gemfile: gemfiles/rails7.2_graphql2.5.gemfile
+                gemfile: rails7.2_graphql2.5
               - ruby-version: '3.0'
-                gemfile: gemfiles/rails7.2_graphql2.6.gemfile
+                gemfile: rails7.2_graphql2.6
               - ruby-version: '3.0'
-                gemfile: gemfiles/rails8.0_graphql2.2.gemfile
+                gemfile: rails8.0_graphql2.2
               - ruby-version: '3.0'
-                gemfile: gemfiles/rails8.0_graphql2.3.gemfile
+                gemfile: rails8.0_graphql2.3
               - ruby-version: '3.0'
-                gemfile: gemfiles/rails8.0_graphql2.4.gemfile
+                gemfile: rails8.0_graphql2.4
               - ruby-version: '3.0'
-                gemfile: gemfiles/rails8.0_graphql2.5.gemfile
+                gemfile: rails8.0_graphql2.5
               - ruby-version: '3.0'
-                gemfile: gemfiles/rails8.0_graphql2.6.gemfile
+                gemfile: rails8.0_graphql2.6
               - ruby-version: '3.0'
-                gemfile: gemfiles/rails8.1_graphql2.4.gemfile
+                gemfile: rails8.1_graphql2.4
               - ruby-version: '3.0'
-                gemfile: gemfiles/rails8.1_graphql2.5.gemfile
+                gemfile: rails8.1_graphql2.5
               - ruby-version: '3.0'
-                gemfile: gemfiles/rails8.1_graphql2.6.gemfile
+                gemfile: rails8.1_graphql2.6
               - ruby-version: '3.1'
-                gemfile: gemfiles/rails8.0_graphql2.2.gemfile
+                gemfile: rails8.0_graphql2.2
               - ruby-version: '3.1'
-                gemfile: gemfiles/rails8.0_graphql2.3.gemfile
+                gemfile: rails8.0_graphql2.3
               - ruby-version: '3.1'
-                gemfile: gemfiles/rails8.0_graphql2.4.gemfile
+                gemfile: rails8.0_graphql2.4
               - ruby-version: '3.1'
-                gemfile: gemfiles/rails8.0_graphql2.5.gemfile
+                gemfile: rails8.0_graphql2.5
               - ruby-version: '3.1'
-                gemfile: gemfiles/rails8.0_graphql2.6.gemfile
+                gemfile: rails8.0_graphql2.6
               - ruby-version: '3.1'
-                gemfile: gemfiles/rails8.1_graphql2.4.gemfile
+                gemfile: rails8.1_graphql2.4
               - ruby-version: '3.1'
-                gemfile: gemfiles/rails8.1_graphql2.5.gemfile
+                gemfile: rails8.1_graphql2.5
               - ruby-version: '3.1'
-                gemfile: gemfiles/rails8.1_graphql2.6.gemfile
+                gemfile: rails8.1_graphql2.6
       - report-coverage:
           requires:
             - test

--- a/graphql_devise.gemspec
+++ b/graphql_devise.gemspec
@@ -33,7 +33,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'zeitwerk'
 
   spec.add_development_dependency 'appraisal'
-  spec.add_development_dependency 'coveralls_reborn'
   spec.add_development_dependency 'factory_bot'
   spec.add_development_dependency 'faker'
   spec.add_development_dependency 'generator_spec'
@@ -46,5 +45,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop-performance', '< 1.6.0'
   spec.add_development_dependency 'rubocop-rails', '< 2.6.0'
   spec.add_development_dependency 'rubocop-rspec', '< 1.39.0'
+  spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'sqlite3'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,9 +2,11 @@
 
 if ENV['CI'] && !ENV['SKIP_COVERALLS']
   require 'simplecov'
-  require 'coveralls'
 
-  SimpleCov.formatter = Coveralls::SimpleCov::Formatter
+  # SimpleCov writes coverage/.resultset.json, which the Coveralls coverage-reporter
+  # (invoked by the coveralls CircleCI orb) picks up and uploads. We no longer upload
+  # from within Ruby so that every parallel job and the parallel_finished webhook share
+  # the same service number and aggregate into a single Coveralls build.
   SimpleCov.start 'rails' do
     add_filter ['spec']
   end


### PR DESCRIPTION
## Problem

The CircleCI `report-coverage` job finished with **0 jobs** reported, and Coveralls showed a **single job** instead of the whole matrix. Two separate bugs:

1. **Split upload / mismatched service number.** Coverage was uploaded from inside each rspec run via `coveralls_reborn` (keyed on the per-job `CIRCLE_BUILD_NUM`), while the final job hit the `parallel_finished` webhook via the orb (keyed on a different number). The webhook always closed out a build with no jobs attached.
2. **No unique `flag_name` per parallel job.** Coveralls uses the flag to distinguish parallel jobs; without one, every job overwrote the previous, collapsing the whole matrix into a single job — and the `done` webhook then had nothing to finalize ("0 jobs").

## Fix

Adopt the reporting model Coveralls recommends and give each job a unique flag:

- Bump coveralls orb `1.0.6` → `2.2.5`
- Drop `coveralls_reborn`; depend on `simplecov` directly
- Remove the Coveralls SimpleCov formatter — SimpleCov just writes `coverage/.resultset.json`, which the orb's coverage-reporter uploads. The reporter uses `CIRCLE_WORKFLOW_ID` as the service number for **both** the per-job `report` and the final `done` webhook, so they aggregate into one build.
- Add `coveralls/upload` (`parallel: true`) to each test job with a unique `flag_name`; keep `parallel_finished` in `report-coverage`
- Carry the bare gemfile id in the matrix (`BUNDLE_GEMFILE` is derived from it) so `flag_name` stays slash-free and valid
- Drop the now-unused `COVERALLS_PARALLEL` job env var

## Note on the token

`COVERALLS_REPO_TOKEN` is already configured in the CircleCI project (uploads succeed; the coverage-reporter hard-fails without it), so no token change is needed for this fix.