### PR TITLE
Use has_no_fields(true) in base types to silence warnings

### DIFF
--- a/lib/graphql_devise/types/mutation_type.rb
+++ b/lib/graphql_devise/types/mutation_type.rb
@@ -4,6 +4,7 @@ module GraphqlDevise
   module Types
     class MutationType < GraphQL::Schema::Object
       field_class GraphqlDevise::Types::BaseField if Gem::Version.new(GraphQL::VERSION) >= Gem::Version.new('2.0')
+      has_no_fields(true) if respond_to?(:has_no_fields)
     end
   end
 end

--- a/lib/graphql_devise/types/query_type.rb
+++ b/lib/graphql_devise/types/query_type.rb
@@ -4,6 +4,7 @@ module GraphqlDevise
   module Types
     class QueryType < GraphQL::Schema::Object
       field_class GraphqlDevise::Types::BaseField if Gem::Version.new(GraphQL::VERSION) >= Gem::Version.new('2.0')
+      has_no_fields(true) if respond_to?(:has_no_fields)
     end
   end
 end


### PR DESCRIPTION
Using `has_no_fields(true)` in the base types to suppress warnings. Apparently this will no longer be used in GraphQl 3.0. So the approach to use `respond_to?` is also future proof. We'll see what direction they take on 3.0

Closes https://github.com/graphql-devise/graphql_devise/issues/283