### PR TITLE
Support public_introspection option in mount_graphql_devise_for

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ jobs:
       - image: 'ruby:<< parameters.ruby-version >>'
     environment:
       BUNDLE_GEMFILE: << parameters.gemfile >>
+      BUNDLE_JOBS: '2'
       COVERALLS_PARALLEL: 'true'
       EAGER_LOAD: 'true'
       RUBYOPT: '-rostruct'

--- a/README.md
+++ b/README.md
@@ -287,6 +287,13 @@ You need to provide a hash to this option, and
 each key will be the name of the query on the schema. Also, the value provided must be a valid Resolver.
 This is also similar to what you can accomplish with
 [devise_scope](https://www.rubydoc.info/github/heartcombo/devise/master/ActionDispatch/Routing/Mapper%3Adevise_for).
+1. `public_introspection`: Defaults to `true`. When set to `false`, introspection fields (`__schema`, `__type`)
+will require authentication on the gem provided schema mounted on a separate route. Given that this schema never
+sets a `current_resource` in the GraphQL context, this effectively disables introspection on that route.
+Please note the gem provided schema is shared by all mounted resources, so setting this option to `false` on any
+mount will disable introspection for all of them. **This option only works if you are using the mount method.**
+If you are mounting the auth operations into your own schema, use the `public_introspection` option of the
+`SchemaPlugin` instead.
 
 Additional mutations and queries will be added to the schema regardless
 of other options you might have specified like `skip` or `only`.
@@ -574,6 +581,9 @@ standard Devise templates.
 ### Disable Introspection
 `GraphqlDevise::Schema` extends from `GraphQL::Schema`, which allows it to utilize the `disable_introspection_entry_points` method. By calling this method, you can disable introspection entry points in your schema. You can read more about it
 [here](https://github.com/rmosolgo/graphql-ruby/blob/master/guides/schema/introspection.md#disabling-introspection).
+
+If you are mounting the auth schema on a separate route, you can also pass `public_introspection: false` to the
+`mount_graphql_devise_for` method. Check the [available mount options](#available-mount-options) section for more information.
 
 If you are using the schema plugin and prefer to make introspection queries available only to authenticated users, you can do so by modifying the `public_introspection` option of the plugin. Check the [plugin config section](#mounting-operations-into-your-own-schema) for more information.
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ GraphqlDevise::Engine.routes.draw do
   # Required as Devise forces routes to reload on eager_load
   unless GraphqlDevise.schema_loaded?
     if GraphqlDevise::Types::QueryType.fields.blank?
-      GraphqlDevise::Types::QueryType.field(:dummy, resolver: GraphqlDevise::Resolvers::Dummy)
+      GraphqlDevise::Types::QueryType.field(:dummy, resolver: GraphqlDevise::Resolvers::Dummy, authenticate: false)
     end
 
     if GraphqlDevise::Types::MutationType.fields.present?

--- a/lib/graphql_devise.rb
+++ b/lib/graphql_devise.rb
@@ -27,8 +27,9 @@ module GraphqlDevise
 
   class InvalidMountOptionsError < ::GraphqlDevise::Error; end
 
-  @schema_loaded     = false
-  @mounted_resources = []
+  @schema_loaded                = false
+  @mounted_resources            = []
+  @introspection_plugin_applied = false
 
   def self.schema_loaded?
     @schema_loaded
@@ -36,6 +37,14 @@ module GraphqlDevise
 
   def self.load_schema
     @schema_loaded = true
+  end
+
+  def self.introspection_plugin_applied?
+    @introspection_plugin_applied
+  end
+
+  def self.introspection_plugin_applied!
+    @introspection_plugin_applied = true
   end
 
   def self.resource_mounted?(model)

--- a/lib/graphql_devise/mount_method/option_sanitizers/boolean_checker.rb
+++ b/lib/graphql_devise/mount_method/option_sanitizers/boolean_checker.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module GraphqlDevise
+  module MountMethod
+    module OptionSanitizers
+      class BooleanChecker
+        def initialize(default_boolean = nil)
+          @default_boolean = default_boolean
+        end
+
+        def call!(value, key)
+          return @default_boolean if value.nil?
+
+          unless value.instance_of?(TrueClass) || value.instance_of?(FalseClass)
+            raise InvalidMountOptionsError, "`#{key}` option has an invalid value. `true` or `false` expected."
+          end
+
+          value
+        end
+      end
+    end
+  end
+end

--- a/lib/graphql_devise/mount_method/supported_options.rb
+++ b/lib/graphql_devise/mount_method/supported_options.rb
@@ -9,7 +9,8 @@ module GraphqlDevise
       skip:                 OptionSanitizers::ArrayChecker.new(Symbol),
       additional_queries:   OptionSanitizers::HashChecker.new(GraphQL::Schema::Resolver),
       additional_mutations: OptionSanitizers::HashChecker.new(GraphQL::Schema::Mutation),
-      authenticatable_type: OptionSanitizers::ClassChecker.new(GraphQL::Schema::Member)
+      authenticatable_type: OptionSanitizers::ClassChecker.new(GraphQL::Schema::Member),
+      public_introspection: OptionSanitizers::BooleanChecker.new(true)
     }.freeze
   end
 end

--- a/lib/graphql_devise/route_mounter.rb
+++ b/lib/graphql_devise/route_mounter.rb
@@ -1,23 +1,36 @@
 module GraphqlDevise
   module RouteMounter
     def mount_graphql_devise_for(resource, options = {})
-      routing = 'graphql_devise/graphql#auth'
-
-      if (base_controller = options.delete(:base_controller))
-        new_controller = GraphqlDevise.const_set("#{resource}AuthController", Class.new(base_controller))
-        new_controller.include(SetUserByToken)
-        new_controller.include(AuthControllerMethods)
-
-        routing = "#{new_controller.to_s.underscore.gsub('_controller','')}#auth"
-      end
+      routing = auth_routing(resource, options.delete(:base_controller))
 
       clean_options = ResourceLoader.new(resource, options, true).call(
         Types::QueryType,
         Types::MutationType
       )
 
+      require_introspection_auth(clean_options)
+
       post clean_options.at, to: routing
       get  clean_options.at, to: routing
+    end
+
+    private
+
+    def auth_routing(resource, base_controller)
+      return 'graphql_devise/graphql#auth' if base_controller.blank?
+
+      new_controller = GraphqlDevise.const_set("#{resource}AuthController", Class.new(base_controller))
+      new_controller.include(SetUserByToken)
+      new_controller.include(AuthControllerMethods)
+
+      "#{new_controller.to_s.underscore.gsub('_controller', '')}#auth"
+    end
+
+    def require_introspection_auth(clean_options)
+      return if clean_options.public_introspection || GraphqlDevise.introspection_plugin_applied?
+
+      Schema.use(SchemaPlugin.new(authenticate_default: true, public_introspection: false))
+      GraphqlDevise.introspection_plugin_applied!
     end
   end
 end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -32,6 +32,12 @@ Rails.application.routes.draw do
     at:   '/api/v1/user_customer/graphql_auth'
   )
 
+  mount_graphql_devise_for(
+    User,
+    at:                   '/api/v1/no_introspection',
+    public_introspection: false
+  )
+
   get '/api/v1/graphql', to: 'api/v1/graphql#graphql'
   post '/api/v1/graphql', to: 'api/v1/graphql#graphql'
   post '/api/v1/interpreter', to: 'api/v1/graphql#interpreter'

--- a/spec/requests/queries/introspection_query_spec.rb
+++ b/spec/requests/queries/introspection_query_spec.rb
@@ -152,4 +152,42 @@ RSpec.describe 'Login Requests' do
       end
     end
   end
+
+  context 'when using the gem provided schema mounted on a route with public_introspection: false' do
+    it 'return an error' do
+      post_request('/api/v1/no_introspection')
+
+      expect(json_response[:data]).to be_nil
+      expect(json_response[:errors]).to contain_exactly(
+        hash_including(
+          message:    '__schema field requires authentication',
+          extensions: { code: 'AUTHENTICATION_ERROR' }
+        )
+      )
+    end
+
+    context 'when executing a regular operation on the same route' do
+      let(:password) { '12345678' }
+      let(:user)     { create(:user, :confirmed, password: password) }
+      let(:query) do
+        <<-GRAPHQL
+          mutation {
+            userLogin(
+              email: "#{user.email}",
+              password: "#{password}"
+            ) {
+              user { email }
+            }
+          }
+        GRAPHQL
+      end
+
+      it 'executes the operation successfully' do
+        post_request('/api/v1/no_introspection')
+
+        expect(json_response[:errors]).to be_nil
+        expect(json_response[:data][:userLogin][:user][:email]).to eq(user.email)
+      end
+    end
+  end
 end

--- a/spec/services/mount_method/option_sanitizers/boolean_checker_spec.rb
+++ b/spec/services/mount_method/option_sanitizers/boolean_checker_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe GraphqlDevise::MountMethod::OptionSanitizers::BooleanChecker do
+  describe '#call!' do
+    subject(:clean_value) { described_class.new(default_boolean).call!(value, key) }
+
+    let(:key)             { :any_option }
+    let(:default_boolean) { true }
+
+    context 'when no value is provided' do
+      let(:value) { nil }
+
+      it { is_expected.to eq(default_boolean) }
+    end
+
+    context 'when provided value is false' do
+      let(:value) { false }
+
+      it 'preserves the explicit false value instead of falling back to the default' do
+        expect(clean_value).to eq(false)
+      end
+    end
+
+    context 'when provided value is true' do
+      let(:value) { true }
+
+      it { is_expected.to eq(true) }
+    end
+
+    context 'when provided value is not a boolean' do
+      let(:value) { 'true' }
+
+      it 'raises an error' do
+        expect { clean_value }.to raise_error(GraphqlDevise::InvalidMountOptionsError, "`#{key}` option has an invalid value. `true` or `false` expected.")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #255. The option was silently ignored by the mount method as it was not part of the supported options. When set to false, the gem now applies the existing SchemaPlugin to the gem provided schema so introspection fields require authentication, same as when mounting operations into a custom schema. Since the mounted route never sets a current_resource in the context, this effectively disables introspection on that route.