### PR TITLE
Add opt-in destroy_account mutation

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,13 @@ Please note the gem provided schema is shared by all mounted resources, so setti
 mount will disable introspection for all of them. **This option only works if you are using the mount method.**
 If you are mounting the auth operations into your own schema, use the `public_introspection` option of the
 `SchemaPlugin` instead.
+1. `allow_destroy`: Defaults to `false`. The `destroy_account` operation is opt-in: it is **not** mounted
+automatically, so upgrading the gem will never add a way to delete accounts to an existing schema. Set
+`allow_destroy: true` to mount it (works alongside `skip`, and additively when no `skip`/`only` is given), or
+list `:destroy_account` in the `only` option. While the operation is available but not mounted, a warning is
+logged on boot explaining how to opt in. If you have decided you don't want the mutation and want to silence
+the warning, add `:destroy_account` to the `skip` option (for example `skip: [:destroy_account]`, or combined
+with the flag as `allow_destroy: true, skip: [:destroy_account]`).
 
 Additional mutations and queries will be added to the schema regardless
 of other options you might have specified like `skip` or `only`.
@@ -315,6 +322,7 @@ The following is a list of the symbols you can provide to the `operations`, `ski
 :send_password_reset_with_token
 :resend_confirmation_with_token
 :confirm_registration_with_token
+:destroy_account # opt-in, see the `allow_destroy` option above
 ```
 
 ### Configuring Model
@@ -479,6 +487,7 @@ register | The parameter `confirmUrl` is optional unless you are using the `conf
 sendPasswordResetWithToken | Sends an email to the provided address with a link to reset the password of the resource. First step of the most recently implemented password reset flow. | userSendPasswordResetWithToken(email: String!, redirectUrl: String!): UserSendPasswordResetWithTokenPayload |
 updatePasswordWithToken | Uses a `resetPasswordToken` to update the password of a resource. Second and last step of the most recently implemented password reset flow. | userSendPasswordResetWithToken(resetPasswordToken: String!, password: String!, passwordConfirmation: String!): UserUpdatePasswordWithTokenPayload |
 resendConfirmationWithToken | The `UserResendConfirmationWithTokenPayload` will return a `message: String!` that can be used to notify a user what to do after the instructions were sent to them. Email will contain a link to the provided `confirmUrl` and a `confirmationToken` query param. | userResendConfirmationWithToken(email: String!, confirmUrl: String!): UserResendConfirmationWithTokenPayload |
+destroyAccount | Opt-in (see the `allow_destroy` mount option). Requires authentication headers. Destroys the current resource and clears the session so no auth headers are returned. | userDestroyAccount: UserDestroyAccountPayload |
 
 ### Reset Password Flow
 This gem supports two password recovery flows. The most recently implemented is preferred and

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,6 +2,7 @@ en:
   graphql_devise:
     redirect_url_not_allowed: "Redirect to '%{redirect_url}' not allowed."
     registration_failed: "User couldn't be registered"
+    destroy_account_failed: "Account couldn't be destroyed"
     resource_build_failed: "Resource couldn't be built, execution stopped."
     not_authenticated: "User is not logged in."
     user_not_found: "User was not found or was not logged in."

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -2,6 +2,7 @@ pt-BR:
   graphql_devise:
     redirect_url_not_allowed: "Redirecionamento para '%{redirect_url}' não permitido."
     registration_failed: "Usuário não pôde ser registrado"
+    destroy_account_failed: "A conta não pôde ser excluída"
     resource_build_failed: "O recurso não pôde ser construído, execução interrompida."
     not_authenticated: "Usuário não logado."
     user_not_found: "Usuário não encontrado ou não logado."

--- a/lib/graphql_devise/default_operations.rb
+++ b/lib/graphql_devise/default_operations.rb
@@ -10,7 +10,8 @@ module GraphqlDevise
       update_password_with_token:      { klass: Mutations::UpdatePasswordWithToken, authenticatable: true },
       send_password_reset_with_token:  { klass: Mutations::SendPasswordResetWithToken, authenticatable: false },
       resend_confirmation_with_token:  { klass: Mutations::ResendConfirmationWithToken, authenticatable: false },
-      confirm_registration_with_token: { klass: Mutations::ConfirmRegistrationWithToken, authenticatable: true }
+      confirm_registration_with_token: { klass: Mutations::ConfirmRegistrationWithToken, authenticatable: true },
+      destroy_account:                 { klass: Mutations::DestroyAccount, authenticatable: true, allow_destroy: true }
     }.freeze
   end
 end

--- a/lib/graphql_devise/mount_method/operation_preparers/default_operation_preparer.rb
+++ b/lib/graphql_devise/mount_method/operation_preparers/default_operation_preparer.rb
@@ -17,7 +17,7 @@ module GraphqlDevise
           @selected_operations.except(*@custom_keys).each_with_object({}) do |(action, operation_info), result|
             mapped_action = "#{mapping_name}_#{action}"
             operation     = operation_info[:klass]
-            options       = operation_info.except(:klass, :deprecation_reason)
+            options       = operation_info.except(:klass, :deprecation_reason, :allow_destroy)
 
             result[mapped_action.to_sym] = [
               OperationPreparers::GqlNameSetter.new(mapped_action),

--- a/lib/graphql_devise/mount_method/operation_sanitizer.rb
+++ b/lib/graphql_devise/mount_method/operation_sanitizer.rb
@@ -3,28 +3,55 @@
 module GraphqlDevise
   module MountMethod
     class OperationSanitizer
-      def self.call(default:, only:, skipped:)
+      def self.call(default:, only:, skipped:, allow_destroy: false)
         new(
-          default: default,
-          only:    only,
-          skipped: skipped
+          default:       default,
+          only:          only,
+          skipped:       skipped,
+          allow_destroy: allow_destroy
         ).call
       end
 
-      def initialize(default:, only:, skipped:)
-        @default = default
-        @only    = only
-        @skipped = skipped
+      def initialize(default:, only:, skipped:, allow_destroy: false)
+        @default       = default
+        @only          = only
+        @skipped       = skipped
+        @allow_destroy = allow_destroy
       end
 
       def call
-        operations = if @only.present?
-          @default.slice(*@only)
-        elsif @skipped.present?
-          @default.except(*@skipped)
-        else
-          @default
+        # When `only` is provided the list is explicit, so `allow_destroy` operations are included
+        # (and never warned about) whenever they are named in it.
+        return @default.slice(*@only) if @only.present?
+
+        selected = @skipped.present? ? @default.except(*@skipped) : @default
+
+        reject_allow_destroy(selected)
+      end
+
+      private
+
+      def reject_allow_destroy(operations)
+        return operations if @allow_destroy
+
+        operations.reject do |name, options|
+          next false unless requires_allow_destroy?(options)
+
+          warn_excluded(name)
+          true
         end
+      end
+
+      def requires_allow_destroy?(options)
+        options.is_a?(Hash) && options[:allow_destroy]
+      end
+
+      def warn_excluded(name)
+        ::Rails.logger&.warn(
+          "[graphql_devise] The `#{name}` operation is not mounted because it is opt-in. " \
+          "Pass `allow_destroy: true` (or add it to the `only:` option) to include it. " \
+          "To keep it out and silence this warning, add `#{name}` to the `skip:` option."
+        )
       end
     end
   end

--- a/lib/graphql_devise/mount_method/supported_options.rb
+++ b/lib/graphql_devise/mount_method/supported_options.rb
@@ -10,7 +10,8 @@ module GraphqlDevise
       additional_queries:   OptionSanitizers::HashChecker.new(GraphQL::Schema::Resolver),
       additional_mutations: OptionSanitizers::HashChecker.new(GraphQL::Schema::Mutation),
       authenticatable_type: OptionSanitizers::ClassChecker.new(GraphQL::Schema::Member),
-      public_introspection: OptionSanitizers::BooleanChecker.new(true)
+      public_introspection: OptionSanitizers::BooleanChecker.new(true),
+      allow_destroy:        OptionSanitizers::BooleanChecker.new(false)
     }.freeze
   end
 end

--- a/lib/graphql_devise/mutations/destroy_account.rb
+++ b/lib/graphql_devise/mutations/destroy_account.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module GraphqlDevise
+  module Mutations
+    class DestroyAccount < Base
+      def resolve
+        raise_user_error(I18n.t('graphql_devise.user_not_found')) unless current_resource
+
+        if current_resource.destroy
+          # Clear the controller resource/token so devise_token_auth's `update_auth_header`
+          # after_action doesn't try to reload the now deleted record.
+          remove_resource
+
+          yield current_resource if block_given?
+
+          { authenticatable: current_resource }
+        else
+          raise_user_error_list(
+            I18n.t('graphql_devise.destroy_account_failed'),
+            resource: current_resource
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/graphql_devise/resource_loader.rb
+++ b/lib/graphql_devise/resource_loader.rb
@@ -117,7 +117,10 @@ module GraphqlDevise
         additional_operations: clean_options.additional_mutations,
         preparer:              MountMethod::OperationPreparers::MutationFieldSetter.new(authenticatable_type),
         selected_operations:   MountMethod::OperationSanitizer.call(
-          default: DefaultOperations::MUTATIONS, only: clean_options.only, skipped: clean_options.skip
+          default:       DefaultOperations::MUTATIONS,
+          only:          clean_options.only,
+          skipped:       clean_options.skip,
+          allow_destroy: clean_options.allow_destroy
         )
       ).call
     end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -7,13 +7,15 @@ Rails.application.routes.draw do
     base_controller: CookiesController,
     operations: { login: Mutations::Login, register: Mutations::Register },
     additional_mutations: { register_confirmed_user: Mutations::RegisterConfirmedUser },
-    additional_queries: { public_user: Resolvers::PublicUser }
+    additional_queries: { public_user: Resolvers::PublicUser },
+    allow_destroy: true
   )
 
   mount_graphql_devise_for(
     Admin,
     authenticatable_type: Types::CustomAdminType,
     skip:                 [:register],
+    allow_destroy:        true,
     operations:           {
       update_password_with_token: Mutations::ResetAdminPasswordWithToken
     },

--- a/spec/requests/mutations/destroy_account_spec.rb
+++ b/spec/requests/mutations/destroy_account_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Destroy Account Requests' do
+  include_context 'with graphql query request'
+
+  let(:user) { create(:user, :confirmed) }
+  let(:query) do
+    <<-GRAPHQL
+      mutation {
+        userDestroyAccount {
+          authenticatable { email }
+        }
+      }
+    GRAPHQL
+  end
+
+  before { post_request }
+
+  context 'when user is logged in' do
+    let(:headers) { user.create_new_auth_token }
+
+    it 'destroys the account and does not set auth headers' do
+      expect(response).not_to include_auth_headers
+      expect(User.exists?(user.id)).to be(false)
+      expect(json_response[:data][:userDestroyAccount]).to match(
+        authenticatable: { email: user.email }
+      )
+      expect(json_response[:errors]).to be_nil
+    end
+  end
+
+  context 'when user is not logged in' do
+    it 'returns an error and does not delete anything' do
+      expect(response).not_to include_auth_headers
+      expect(User.exists?(user.id)).to be(true)
+      expect(json_response[:data][:userDestroyAccount]).to be_nil
+      expect(json_response[:errors]).to contain_exactly(
+        hash_including(message: 'User was not found or was not logged in.', extensions: { code: 'USER_ERROR' })
+      )
+    end
+  end
+
+  context 'when using the admin model' do
+    let(:query) do
+      <<-GRAPHQL
+        mutation {
+          adminDestroyAccount {
+            authenticatable { email }
+          }
+        }
+      GRAPHQL
+    end
+    let(:admin)   { create(:admin, :confirmed) }
+    let(:headers) { admin.create_new_auth_token }
+
+    it 'destroys the admin account' do
+      expect(response).not_to include_auth_headers
+      expect(Admin.exists?(admin.id)).to be(false)
+      expect(json_response[:data][:adminDestroyAccount]).to match(
+        authenticatable: { email: admin.email }
+      )
+      expect(json_response[:errors]).to be_nil
+    end
+  end
+end

--- a/spec/services/mount_method/operation_sanitizer_spec.rb
+++ b/spec/services/mount_method/operation_sanitizer_spec.rb
@@ -4,11 +4,14 @@ require 'rails_helper'
 
 RSpec.describe GraphqlDevise::MountMethod::OperationSanitizer do
   describe '.call' do
-    subject { described_class.call(default: default, only: only, skipped: skipped) }
+    subject(:sanitized) do
+      described_class.call(default: default, only: only, skipped: skipped, allow_destroy: allow_destroy)
+    end
 
     let(:op_class1) { Class.new }
     let(:op_class2) { Class.new }
     let(:op_class3) { Class.new }
+    let(:allow_destroy) { false }
 
     context 'when the operations passed are mutations' do
       let(:skipped)  { [] }
@@ -29,6 +32,60 @@ RSpec.describe GraphqlDevise::MountMethod::OperationSanitizer do
         let(:skipped) { [:operation2] }
 
         it { is_expected.to eq(operation1: { klass: op_class1 }) }
+      end
+    end
+
+    context 'when an operation requires the allow_destroy option' do
+      let(:skipped) { [] }
+      let(:only)    { [] }
+      let(:default) do
+        {
+          operation1:      { klass: op_class1 },
+          destroy_account: { klass: op_class2, allow_destroy: true }
+        }
+      end
+
+      context 'when no only/skip option and allow_destroy is off' do
+        it 'excludes the operation and logs a warning' do
+          expect(Rails.logger).to receive(:warn).with(/destroy_account/)
+          expect(sanitized).to eq(operation1: { klass: op_class1 })
+        end
+      end
+
+      context 'when using skip on other operations without allow_destroy' do
+        let(:skipped) { [:operation1] }
+
+        it 'still excludes the operation and logs a warning' do
+          expect(Rails.logger).to receive(:warn).with(/destroy_account/)
+          expect(sanitized).to eq({})
+        end
+      end
+
+      context 'when the operation itself is skipped' do
+        let(:skipped) { [:destroy_account] }
+
+        it 'excludes the operation without logging a warning' do
+          expect(Rails.logger).not_to receive(:warn)
+          expect(sanitized).to eq(operation1: { klass: op_class1 })
+        end
+      end
+
+      context 'when allow_destroy is on' do
+        let(:allow_destroy) { true }
+
+        it 'includes the operation without warning' do
+          expect(Rails.logger).not_to receive(:warn)
+          expect(sanitized).to eq(default)
+        end
+      end
+
+      context 'when named explicitly in only' do
+        let(:only) { [:destroy_account] }
+
+        it 'includes the operation without warning' do
+          expect(Rails.logger).not_to receive(:warn)
+          expect(sanitized).to eq(destroy_account: { klass: op_class2, allow_destroy: true })
+        end
       end
     end
   end


### PR DESCRIPTION
## Summary

Adds a `destroy_account` mutation that lets an authenticated resource delete its own account, and fixes the `ActiveRecord::RecordNotFound` crash reported when doing so.

- The mutation destroys `current_resource`, then calls the existing `remove_resource` helper, nil-ing the controller resource so devise_token_auth's `after_action :update_auth_header` short-circuits before reloading the deleted record. This mirrors how `Logout` already avoids the same callback.
- Naming/behavior follows Devise + DTA `RegistrationsController#destroy`: verb `destroy`, no password, returns `{ authenticatable: current_resource }`, yields the resource.

## Opt-in

The operation is **opt-in** so upgrading the gem never adds account deletion to an existing schema automatically.

- Registered with an `allow_destroy` marker in `DefaultOperations::MUTATIONS` and gated by a new `allow_destroy` mount option (default `false`).
- **Enable:** `allow_destroy: true` (additive, also works alongside `skip`), or list `:destroy_account` in `only`.
- **Upgraders are safe:** no-option and `skip:` users don't get it automatically.
- **Warning + silence:** while available but not mounted, a `Rails.logger.warn` explains how to opt in and notes that adding `:destroy_account` to `skip` keeps it out and silences the warning.

## Tests

Full suite green (182 examples, 0 failures). New coverage:
- Request spec: signed-in destroy returns no auth headers (proves the crash fix), not-signed-in error, admin model via `skip` + `allow_destroy`.
- `OperationSanitizer` unit specs for every opt-in / warn / silence combination.

Fixes #162, #163